### PR TITLE
Fix API endpoint with uppercase letters

### DIFF
--- a/cloudnet-core/src/main/java/de/dytanic/cloudnetcore/web/api/v1/WebsiteUtils.java
+++ b/cloudnet-core/src/main/java/de/dytanic/cloudnetcore/web/api/v1/WebsiteUtils.java
@@ -148,7 +148,7 @@ public class WebsiteUtils extends MethodWebHandlerAdapter {
                 fullHttpResponse.setStatus(HttpResponseStatus.OK);
                 fullHttpResponse.content().writeBytes(dataDocument.convertToJsonString().getBytes(StandardCharsets.UTF_8));
                 return fullHttpResponse;
-            case "startServer":
+            case "startserver":
 
                 if(!user.getPermissions().contains("cloudnet.web.startserver") && !user.getPermissions().contains("*"))
                 {


### PR DESCRIPTION
The uppercase `S` prevented anyone from using the `startserver` message. It now works again.