### PR TITLE
Build Javadocs and remove examples from being built

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
     }
     stage('Re-package') {
       steps {
-        sh 'mvn package javadoc:aggregate'
+        sh 'mvn package javadoc:aggregate-jar'
       }
     }
     stage('Archive') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
     }
     stage('Archive') {
       steps {
-        archiveArtifacts allowEmptyArchive: true, artifacts: '**/target/CloudNet-Wrapper.jar,**/target/CloudNet-Master.jar,**/target/CloudNetAPI.jar', fingerprint: true, onlyIfSuccessful: true
+        archiveArtifacts allowEmptyArchive: true, artifacts: '**/target/CloudNet-Wrapper.jar,**/target/CloudNet-Master.jar,**/target/CloudNetAPI.jar,target/cloudnet-*-javadoc.jar', fingerprint: true, onlyIfSuccessful: true
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,8 @@ pipeline {
     }
     stage('Archive') {
       steps {
-        archiveArtifacts allowEmptyArchive: true, artifacts: '**/target/CloudNet-Wrapper.jar,**/target/CloudNet-Master.jar,**/target/CloudNetAPI.jar', fingerprint: true, onlyIfSuccessful: true      }
+        archiveArtifacts allowEmptyArchive: true, artifacts: '**/target/CloudNet-Wrapper.jar,**/target/CloudNet-Master.jar,**/target/CloudNetAPI.jar', fingerprint: true, onlyIfSuccessful: true
+      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
     }
     stage('Re-package') {
       steps {
-        sh 'mvn -Xdoclint:none package javadoc:aggregate'
+        sh 'mvn package javadoc:aggregate'
       }
     }
     stage('Archive') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
     }
     stage('Re-package') {
       steps {
-        sh 'mvn package javadoc:aggregate'
+        sh 'mvn package javadoc:aggregate -Xdoclint:none'
       }
     }
     stage('Archive') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
     }
     stage('Re-package') {
       steps {
-        sh 'mvn package javadoc:aggregate -Xdoclint:none'
+        sh 'mvn -Xdoclint:none package javadoc:aggregate'
       }
     }
     stage('Archive') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
     }
     stage('Re-package') {
       steps {
-        sh 'mvn package'
+        sh 'mvn package javadoc:aggregate'
       }
     }
     stage('Archive') {

--- a/cloudnet-lib/pom.xml
+++ b/cloudnet-lib/pom.xml
@@ -62,7 +62,7 @@
             <plugin>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok-maven-plugin</artifactId>
-                <version>1.16.6.1</version>
+                <version>1.18.0.0</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,6 @@
         <module>cloudnet-wrapper</module>
         <module>cloudnet-api</module>
         <module>cloudnet-tools</module>
-        <module>cloudnet-examples</module>
         <module>cloudnet-modules</module>
     </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
                     <execution>
                         <id>aggregate</id>
                         <goals>
-                            <goal>aggregate</goal>
+                            <goal>aggregate-jar</goal>
                         </goals>
                         <phase>compile</phase>
                         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.1</version>
+                <configuration>
+                    <show>private</show>
+                    <additionalJOption>-Xdoclint:none</additionalJOption>
+                </configuration>
                 <executions>
                     <execution>
                         <id>aggregate</id>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
                         <goals>
                             <goal>aggregate-jar</goal>
                         </goals>
-                        <phase>compile</phase>
+                        <phase>site</phase>
                         <configuration>
                             <show>private</show>
                             <additionalJOption>-Xdoclint:none</additionalJOption>

--- a/pom.xml
+++ b/pom.xml
@@ -47,4 +47,27 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>aggregate</id>
+                        <goals>
+                            <goal>aggregate</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <show>private</show>
+                            <additionalJOption>-Xdoclint:none</additionalJOption>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
This PR allows Jenkins and everyone else to easily build the Javadocs.

The provided configuration ignores linting errors from missing parameters and also shows private fields and methods for ease of development.

Because the examples don't really make sense to be compiled or occur in the documentation.

This also updates the Maven Lombok plugin.

The documentation can be found in the `target`directory of the root project.

I have uploaded the latest version here: [cloudnet-2.1.5-SNAPSHOT-javadoc.jar](https://github.com/CloudNetService/CloudNet/files/2121171/cloudnet-2.1.5-SNAPSHOT-javadoc.jar.zip)

I can only upload ZIP files here, but it comes in the generally used JAR format that can easily be imported into any IDE.