### PR TITLE
Fix update config database

### DIFF
--- a/cloudnet-core/src/main/java/de/dytanic/cloudnetcore/database/DatabaseBasicHandlers.java
+++ b/cloudnet-core/src/main/java/de/dytanic/cloudnetcore/database/DatabaseBasicHandlers.java
@@ -39,6 +39,8 @@ public class DatabaseBasicHandlers {
         wrapperSessionDatabase = new WrapperSessionDatabase(databaseManager.getDatabase("cloudnet_internal_wrapper_session"));
         updateConfigurationDatabase = new UpdateConfigurationDatabase(config);
 
+        nameToUUIDDatabase.handleUpdate(updateConfigurationDatabase);
+
         ((DatabaseImpl)config).save();
     }
 }

--- a/cloudnet-core/src/main/java/de/dytanic/cloudnetcore/database/DatabaseBasicHandlers.java
+++ b/cloudnet-core/src/main/java/de/dytanic/cloudnetcore/database/DatabaseBasicHandlers.java
@@ -39,8 +39,6 @@ public class DatabaseBasicHandlers {
         wrapperSessionDatabase = new WrapperSessionDatabase(databaseManager.getDatabase("cloudnet_internal_wrapper_session"));
         updateConfigurationDatabase = new UpdateConfigurationDatabase(config);
 
-        nameToUUIDDatabase.handleUpdate(updateConfigurationDatabase);
-
         ((DatabaseImpl)config).save();
     }
 }

--- a/cloudnet-core/src/main/java/de/dytanic/cloudnetcore/database/NameToUUIDDatabase.java
+++ b/cloudnet-core/src/main/java/de/dytanic/cloudnetcore/database/NameToUUIDDatabase.java
@@ -12,6 +12,8 @@ import de.dytanic.cloudnet.lib.database.Database;
 import de.dytanic.cloudnet.lib.database.DatabaseDocument;
 import de.dytanic.cloudnet.lib.utility.document.Document;
 
+import java.util.Collection;
+import java.util.LinkedList;
 import java.util.UUID;
 
 /**
@@ -66,5 +68,24 @@ public final class NameToUUIDDatabase extends DatabaseUseable {
             return document.getString("name");
         }
         return null;
+    }
+
+    public void handleUpdate(UpdateConfigurationDatabase updateConfigurationDatabase) {
+        final String updateKey = "updated_database_from_2_1_Pv29";
+        if (!updateConfigurationDatabase.get().contains(updateKey)) {
+            Collection<Document> documents = new LinkedList<>(database.loadDocuments().getDocs());
+
+            documents.forEach(document -> {
+                String name = document.getString(Database.UNIQUE_NAME_KEY);
+                if (name != null && name.length() < 32) {
+                    database.delete(name);
+                    database.insert(document.append(Database.UNIQUE_NAME_KEY, name.toLowerCase()));
+                }
+            });
+
+            updateConfigurationDatabase.set(updateConfigurationDatabase.get().append(updateKey, true));
+            ((DatabaseImpl) database).save();
+            ((DatabaseImpl) database).clear();
+        }
     }
 }

--- a/cloudnet-core/src/main/java/de/dytanic/cloudnetcore/database/NameToUUIDDatabase.java
+++ b/cloudnet-core/src/main/java/de/dytanic/cloudnetcore/database/NameToUUIDDatabase.java
@@ -20,63 +20,54 @@ import java.util.UUID;
  */
 public final class NameToUUIDDatabase extends DatabaseUseable {
 
-    public NameToUUIDDatabase(Database database)
-    {
+    public NameToUUIDDatabase(Database database) {
         super(database);
     }
 
     @Deprecated
-    public void handleUpdate(UpdateConfigurationDatabase updateConfigurationDatabase)
-    {
+    public void handleUpdate(UpdateConfigurationDatabase updateConfigurationDatabase) {
 
-        if (!updateConfigurationDatabase.get().contains("updated_database_from_2_1_Pv29"))
-        {
+        if (!updateConfigurationDatabase.get().contains("updated_database_from_2_1_Pv29")) {
             Collection<Document> documents = database.loadDocuments().getDocs();
             String name;
 
-            for (Document document : documents)
-            {
+            for (Document document: documents) {
                 name = document.getString(Database.UNIQUE_NAME_KEY);
 
                 if (name != null)
-                    if (name.length() < 32)
-                    {
+                    if (name.length() < 32) {
                         database.delete(document.getString(Database.UNIQUE_NAME_KEY));
                         database.insert(document.append(Database.UNIQUE_NAME_KEY, name.toLowerCase()));
                     }
             }
 
             updateConfigurationDatabase.set(updateConfigurationDatabase.get().append("updated_database_from_2_1_Pv29", true));
+            ((DatabaseImpl) updateConfigurationDatabase.getDatabase()).save();
             ((DatabaseImpl) database).save();
             ((DatabaseImpl) database).clear();
         }
     }
 
-    public DatabaseImpl a()
-    {
+    public DatabaseImpl getDatabaseImplementation() {
         return ((DatabaseImpl) database);
     }
 
-    public void append(MultiValue<String, UUID> values)
-    {
+    public void append(MultiValue<String, UUID> values) {
         database.insert(new DatabaseDocument(values.getFirst().toLowerCase()).append("uniqueId", values.getSecond()));
 
         database.insert(new DatabaseDocument(values.getSecond().toString()).append("name", values.getFirst()));
     }
 
-    public void replace(MultiValue<UUID, String> replacer)
-    {
+    public void replace(MultiValue<UUID, String> replacer) {
         Document document = database.getDocument(replacer.getFirst().toString());
         document.append("name", replacer.getSecond());
         database.insert(document);
     }
 
-    public UUID get(String name)
-    {
+    public UUID get(String name) {
         if (name == null) return null;
 
-        if (a().containsDoc(name.toLowerCase()))
-        {
+        if (getDatabaseImplementation().containsDoc(name.toLowerCase())) {
             Document document = database.getDocument(name.toLowerCase());
             if (!document.contains("uniqueId")) {
                 database.delete(name.toLowerCase());
@@ -88,12 +79,10 @@ public final class NameToUUIDDatabase extends DatabaseUseable {
         return null;
     }
 
-    public String get(UUID uniqueId)
-    {
+    public String get(UUID uniqueId) {
         if (uniqueId == null) return null;
 
-        if (a().containsDoc(uniqueId.toString()))
-        {
+        if (getDatabaseImplementation().containsDoc(uniqueId.toString())) {
             Document document = database.getDocument(uniqueId.toString());
             if (!document.contains("name")) {
                 database.delete(uniqueId.toString());

--- a/cloudnet-core/src/main/java/de/dytanic/cloudnetcore/database/NameToUUIDDatabase.java
+++ b/cloudnet-core/src/main/java/de/dytanic/cloudnetcore/database/NameToUUIDDatabase.java
@@ -29,16 +29,16 @@ public final class NameToUUIDDatabase extends DatabaseUseable {
 
         if (!updateConfigurationDatabase.get().contains("updated_database_from_2_1_Pv29")) {
             Collection<Document> documents = database.loadDocuments().getDocs();
-            String name;
+
+            System.out.println("Updating " + documents.size() + " documents...");
 
             for (Document document: documents) {
-                name = document.getString(Database.UNIQUE_NAME_KEY);
+                String name = document.getString(Database.UNIQUE_NAME_KEY);
 
-                if (name != null)
-                    if (name.length() < 32) {
-                        database.delete(document.getString(Database.UNIQUE_NAME_KEY));
-                        database.insert(document.append(Database.UNIQUE_NAME_KEY, name.toLowerCase()));
-                    }
+                if (name != null && name.length() < 32) {
+                    database.delete(document.getString(Database.UNIQUE_NAME_KEY));
+                    database.insert(document.append(Database.UNIQUE_NAME_KEY, name.toLowerCase()));
+                }
             }
 
             updateConfigurationDatabase.set(updateConfigurationDatabase.get().append("updated_database_from_2_1_Pv29", true));

--- a/cloudnet-core/src/main/java/de/dytanic/cloudnetcore/database/NameToUUIDDatabase.java
+++ b/cloudnet-core/src/main/java/de/dytanic/cloudnetcore/database/NameToUUIDDatabase.java
@@ -12,7 +12,6 @@ import de.dytanic.cloudnet.lib.database.Database;
 import de.dytanic.cloudnet.lib.database.DatabaseDocument;
 import de.dytanic.cloudnet.lib.utility.document.Document;
 
-import java.util.Collection;
 import java.util.UUID;
 
 /**
@@ -22,30 +21,6 @@ public final class NameToUUIDDatabase extends DatabaseUseable {
 
     public NameToUUIDDatabase(Database database) {
         super(database);
-    }
-
-    @Deprecated
-    public void handleUpdate(UpdateConfigurationDatabase updateConfigurationDatabase) {
-
-        if (!updateConfigurationDatabase.get().contains("updated_database_from_2_1_Pv29")) {
-            Collection<Document> documents = database.loadDocuments().getDocs();
-
-            System.out.println("Updating " + documents.size() + " documents...");
-
-            for (Document document: documents) {
-                String name = document.getString(Database.UNIQUE_NAME_KEY);
-
-                if (name != null && name.length() < 32) {
-                    database.delete(document.getString(Database.UNIQUE_NAME_KEY));
-                    database.insert(document.append(Database.UNIQUE_NAME_KEY, name.toLowerCase()));
-                }
-            }
-
-            updateConfigurationDatabase.set(updateConfigurationDatabase.get().append("updated_database_from_2_1_Pv29", true));
-            ((DatabaseImpl) updateConfigurationDatabase.getDatabase()).save();
-            ((DatabaseImpl) database).save();
-            ((DatabaseImpl) database).clear();
-        }
     }
 
     public DatabaseImpl getDatabaseImplementation() {


### PR DESCRIPTION
The updater hang because changes are only saved once a minute and changes to a `ConcurrentHashMap` reset the iterator.

This pull request fixes this issue by using a local copy of the document references such that any change in the iterator of the database does not affect this updater.

