### PR TITLE
Fix two issues in the document class

### DIFF
--- a/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/utility/document/Document.java
+++ b/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/utility/document/Document.java
@@ -152,6 +152,10 @@ public class Document
     public Document append(String key, Object value)
     {
         if (value == null) return this;
+        if(value instanceof Document) {
+            this.append(key, (Document) value);
+            return this;
+        }
         this.dataCatcher.add(key, GSON.toJsonTree(value));
         return this;
     }

--- a/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/utility/document/Document.java
+++ b/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/utility/document/Document.java
@@ -242,8 +242,8 @@ public class Document
 
     public Document getDocument(String key)
     {
-        Document document = new Document(dataCatcher.get(key).getAsJsonObject());
-        return document;
+        if (!dataCatcher.has(key)) return null;
+        return new Document(dataCatcher.get(key).getAsJsonObject());
     }
 
     public Document clear()


### PR DESCRIPTION
- Fixed a throw of a NPE when trying to get a document which key doesn't exist with the getDocument-Method
- Added a check, if the given value in the append-Method is a document and if yes, adding only the dataCatcher, not the whole document. (Found by @McRuben)