### PR TITLE
Fixed issues with the SignSelector and the MobSelector in MC 1.13+

### DIFF
--- a/cloudnet-api/cloudnet-api-bridge/src/main/java/de/dytanic/cloudnet/bridge/event/bukkit/BukkitCloudEvent.java
+++ b/cloudnet-api/cloudnet-api-bridge/src/main/java/de/dytanic/cloudnet/bridge/event/bukkit/BukkitCloudEvent.java
@@ -6,6 +6,7 @@ package de.dytanic.cloudnet.bridge.event.bukkit;
 
 import de.dytanic.cloudnet.api.CloudAPI;
 import de.dytanic.cloudnet.bridge.CloudServer;
+import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 
 /**
@@ -14,10 +15,10 @@ import org.bukkit.event.Event;
 public abstract class BukkitCloudEvent extends Event {
 
     /**
-     * Marks BukkitCloudEvents as async
+     * Marks this BukkitCloudEvent as async or sync based on on which thread it's being called
      */
     public BukkitCloudEvent() {
-        super(true);
+        super(!Bukkit.isPrimaryThread());
     }
 
     /**

--- a/cloudnet-api/cloudnet-api-bridge/src/main/java/de/dytanic/cloudnet/bridge/internal/command/bukkit/CommandCloudServer.java
+++ b/cloudnet-api/cloudnet-api-bridge/src/main/java/de/dytanic/cloudnet/bridge/internal/command/bukkit/CommandCloudServer.java
@@ -75,12 +75,20 @@ public final class CommandCloudServer implements CommandExecutor, TabExecutor {
 
                         if (stringBuilder.length() > 32)
                         {
-                            commandSender.sendMessage(CloudAPI.getInstance().getPrefix() + "The display cannot be longe then 32 characters");
+                            commandSender.sendMessage(CloudAPI.getInstance().getPrefix() + "The display cannot be longer then 32 characters");
                             return false;
                         }
+
+                        String material = args[4].toUpperCase();
+
+                        if(Material.getMaterial(material) == null)
+                        {
+                            commandSender.sendMessage(CloudAPI.getInstance().getPrefix() + "An item with this itemName does not exist");
+                            return false;
+                        }
+
                         ServerMob serverMob = new ServerMob(UUID.randomUUID(), stringBuilder.substring(0, stringBuilder.length() - 1), args[2], entityType.name(), args[3],
-                                NetworkUtils.checkIsNumber(args[4]) ? (Integer.parseInt(args[4]) != 0 ? Integer.parseInt(args[4]) : 138) : 138
-                                , args[5].equalsIgnoreCase("true"),
+                                -1, material, args[5].equalsIgnoreCase("true"),
                                 MobSelector.getInstance().toPosition(CloudAPI.getInstance().getGroup(), player.getLocation()), "§8#§c%group% &bPlayers online §8|§7 %group_online% of %max_players%", new Document());
                         CloudAPI.getInstance().getNetworkConnection().sendPacket(new PacketOutAddMob(serverMob));
                         player.sendMessage(CloudAPI.getInstance().getPrefix() + "The mob will be created, please wait...");
@@ -340,7 +348,7 @@ public final class CommandCloudServer implements CommandExecutor, TabExecutor {
                 }
                 if (MobSelector.getInstance() != null)
                 {
-                    commandSender.sendMessage(CloudAPI.getInstance().getPrefix() + "/cs createMob <entityType> <name> <targetGroup> <itemId> <autoJoin> <displayName>");
+                    commandSender.sendMessage(CloudAPI.getInstance().getPrefix() + "/cs createMob <entityType> <name> <targetGroup> <itemName> <autoJoin> <displayName>");
                     commandSender.sendMessage(CloudAPI.getInstance().getPrefix() + "/cs removeMob <name>");
                     commandSender.sendMessage(CloudAPI.getInstance().getPrefix() + "/cs listMobs");
                     commandSender.sendMessage(CloudAPI.getInstance().getPrefix() + "/cs moblist");

--- a/cloudnet-api/cloudnet-api-bridge/src/main/java/de/dytanic/cloudnet/bridge/internal/serverselectors/MobSelector.java
+++ b/cloudnet-api/cloudnet-api-bridge/src/main/java/de/dytanic/cloudnet/bridge/internal/serverselectors/MobSelector.java
@@ -156,7 +156,8 @@ public final class MobSelector {
 
     private ItemStack transform(MobItemLayout mobItemLayout)
     {
-        return ItemStackBuilder.builder(mobItemLayout.getItemId(), 1, mobItemLayout.getSubId())
+        Material material = ItemStackBuilder.getMaterialIgnoreVersion(mobItemLayout.getItemName(), mobItemLayout.getItemId());
+        return material == null ? null : ItemStackBuilder.builder(material, 1, mobItemLayout.getSubId())
                 .lore(new ArrayList<>(CollectionWrapper.transform(mobItemLayout.getLore(), new Catcher<String, String>() {
                     @Override
                     public String doCatch(String key)
@@ -168,7 +169,8 @@ public final class MobSelector {
 
     private ItemStack transform(MobItemLayout mobItemLayout, ServerInfo serverInfo)
     {
-        return ItemStackBuilder.builder(mobItemLayout.getItemId(), 1, mobItemLayout.getSubId())
+        Material material = ItemStackBuilder.getMaterialIgnoreVersion(mobItemLayout.getItemName(), mobItemLayout.getItemId());
+        return material == null ? null :  ItemStackBuilder.builder(material, 1, mobItemLayout.getSubId())
                 .lore(new ArrayList<>(CollectionWrapper.transform(mobItemLayout.getLore(), new Catcher<String, String>() {
                     @Override
                     public String doCatch(String key)
@@ -457,7 +459,7 @@ public final class MobSelector {
             if (inventories().contains(e.getInventory()) && e.getCurrentItem() != null && e.getSlot() == e.getRawSlot())
             {
                 e.setCancelled(true);
-                if (mobConfig.getItemLayout().getItemId() == e.getCurrentItem().getTypeId())
+                if (ItemStackBuilder.getMaterialIgnoreVersion(mobConfig.getItemLayout().getItemName(), mobConfig.getItemLayout().getItemId()) == e.getCurrentItem().getType())
                 {
                     MobImpl mob = find(e.getInventory());
                     if (mob.getServerPosition().containsKey(e.getSlot()))
@@ -517,10 +519,13 @@ public final class MobSelector {
                                 Entity armor = (Entity) armorStand;
                                 if (armor.getPassenger() == null && key.getItemId() != null)
                                 {
-                                    Item item = Bukkit.getWorld(key.getPosition().getWorld()).dropItem(armor.getLocation(), new ItemStack(key.getItemId()));
-                                    item.setPickupDelay(Integer.MAX_VALUE);
-                                    item.setTicksLived(Integer.MAX_VALUE);
-                                    armor.setPassenger(item);
+                                    Material material = ItemStackBuilder.getMaterialIgnoreVersion(key.getItemName(), key.getItemId());
+                                    if(material != null) {
+                                        Item item = Bukkit.getWorld(key.getPosition().getWorld()).dropItem(armor.getLocation(), new ItemStack(material));
+                                        item.setPickupDelay(Integer.MAX_VALUE);
+                                        item.setTicksLived(Integer.MAX_VALUE);
+                                        armor.setPassenger(item);
+                                    }
                                 }
                             }
 

--- a/cloudnet-api/cloudnet-api-bridge/src/main/java/de/dytanic/cloudnet/bridge/internal/serverselectors/packet/in/PacketInMobSelector.java
+++ b/cloudnet-api/cloudnet-api-bridge/src/main/java/de/dytanic/cloudnet/bridge/internal/serverselectors/packet/in/PacketInMobSelector.java
@@ -10,6 +10,7 @@ import de.dytanic.cloudnet.api.network.packet.PacketInHandlerDefault;
 import de.dytanic.cloudnet.bridge.CloudServer;
 import de.dytanic.cloudnet.bridge.event.bukkit.BukkitMobInitEvent;
 import de.dytanic.cloudnet.bridge.internal.serverselectors.MobSelector;
+import de.dytanic.cloudnet.bridge.internal.util.ItemStackBuilder;
 import de.dytanic.cloudnet.bridge.internal.util.ReflectionUtil;
 import de.dytanic.cloudnet.lib.NetworkUtils;
 import de.dytanic.cloudnet.lib.network.protocol.packet.PacketSender;
@@ -39,8 +40,7 @@ import java.util.UUID;
 public class PacketInMobSelector extends PacketInHandlerDefault {
 
     @Override
-    public void handleInput(Document data, PacketSender packetSender)
-    {
+    public void handleInput(Document data, PacketSender packetSender) {
         Map<UUID, ServerMob> mobMap = data.getObject("mobs", new TypeToken<Map<UUID, ServerMob>>() {
         }.getType());
         MobConfig mobConfig = data.getObject("mobConfig", new TypeToken<MobConfig>() {
@@ -48,53 +48,48 @@ public class PacketInMobSelector extends PacketInHandlerDefault {
 
         Map<UUID, ServerMob> filteredMobs = MapWrapper.filter(mobMap, new Acceptable<ServerMob>() {
             @Override
-            public boolean isAccepted(ServerMob value)
-            {
+            public boolean isAccepted(ServerMob value) {
                 return value.getPosition().getGroup().equalsIgnoreCase(CloudAPI.getInstance().getGroup());
             }
         });
 
-        if (MobSelector.getInstance() != null)
-        {
+        if (MobSelector.getInstance() != null) {
             Bukkit.getScheduler().runTask(CloudServer.getInstance().getPlugin(), new Runnable() {
                 @Override
-                public void run()
-                {
+                public void run() {
                     MobSelector.getInstance().shutdown();
                     MobSelector.getInstance().setMobConfig(mobConfig);
                     MobSelector.getInstance().setMobs(new HashMap<>());
                     MobSelector.getInstance().setMobs(MapWrapper.transform(filteredMobs, new Catcher<UUID, UUID>() {
                         @Override
-                        public UUID doCatch(UUID key)
-                        {
+                        public UUID doCatch(UUID key) {
                             return key;
                         }
                     }, new Catcher<MobSelector.MobImpl, ServerMob>() {
 
                         @Override
-                        public MobSelector.MobImpl doCatch(ServerMob key)
-                        {
+                        public MobSelector.MobImpl doCatch(ServerMob key) {
                             MobSelector.getInstance().toLocation(key.getPosition()).getChunk().load();
                             Entity entity = MobSelector.getInstance().toLocation(key.getPosition()).getWorld().spawnEntity(MobSelector.getInstance().toLocation(key.getPosition()), EntityType.valueOf(key.getType()));
                             entity.setFireTicks(0);
                             Object armorStand = ReflectionUtil.armorstandCreation(MobSelector.getInstance().toLocation(key.getPosition()), entity, key);
 
-                            if (armorStand != null)
-                            {
+                            if (armorStand != null) {
                                 MobSelector.getInstance().updateCustom(key, armorStand);
                                 Entity armor = (Entity) armorStand;
-                                if (armor.getPassenger() == null && key.getItemId() != null)
-                                {
+                                if (armor.getPassenger() == null && key.getItemId() != null) {
 
-                                    Item item = Bukkit.getWorld(key.getPosition().getWorld()).dropItem(armor.getLocation(), new ItemStack(Material.getMaterial(key.getItemId())));
-                                    item.setTicksLived(Integer.MAX_VALUE);
-                                    item.setPickupDelay(Integer.MAX_VALUE);
-                                    armor.setPassenger(item);
+                                    Material material = ItemStackBuilder.getMaterialIgnoreVersion(key.getItemName(), key.getItemId());
+                                    if(material != null) {
+                                        Item item = Bukkit.getWorld(key.getPosition().getWorld()).dropItem(armor.getLocation(), new ItemStack(material));
+                                        item.setTicksLived(Integer.MAX_VALUE);
+                                        item.setPickupDelay(Integer.MAX_VALUE);
+                                        armor.setPassenger(item);
+                                    }
                                 }
                             }
 
-                            if (entity instanceof Villager)
-                            {
+                            if (entity instanceof Villager) {
                                 ((Villager) entity).setProfession(Villager.Profession.FARMER);
                             }
 
@@ -108,10 +103,8 @@ public class PacketInMobSelector extends PacketInHandlerDefault {
                     }));
                     Bukkit.getScheduler().runTaskAsynchronously(CloudServer.getInstance().getPlugin(), new Runnable() {
                         @Override
-                        public void run()
-                        {
-                            for (ServerInfo serverInfo : MobSelector.getInstance().getServers().values())
-                            {
+                        public void run() {
+                            for (ServerInfo serverInfo : MobSelector.getInstance().getServers().values()) {
                                 MobSelector.getInstance().handleUpdate(serverInfo);
                             }
                         }
@@ -119,43 +112,39 @@ public class PacketInMobSelector extends PacketInHandlerDefault {
                 }
             });
 
-        } else
-        {
+        } else {
             MobSelector mobSelector = new MobSelector(mobConfig);
             MobSelector.getInstance().setMobs(new HashMap<>());
             Bukkit.getScheduler().runTask(CloudServer.getInstance().getPlugin(), new Runnable() {
                 @Override
-                public void run()
-                {
+                public void run() {
                     MobSelector.getInstance().setMobs(MapWrapper.transform(filteredMobs, new Catcher<UUID, UUID>() {
                         @Override
-                        public UUID doCatch(UUID key)
-                        {
+                        public UUID doCatch(UUID key) {
                             return key;
                         }
                     }, new Catcher<MobSelector.MobImpl, ServerMob>() {
                         @Override
-                        public MobSelector.MobImpl doCatch(ServerMob key)
-                        {
+                        public MobSelector.MobImpl doCatch(ServerMob key) {
                             MobSelector.getInstance().toLocation(key.getPosition()).getChunk().load();
                             Entity entity = MobSelector.getInstance().toLocation(key.getPosition()).getWorld().spawnEntity(MobSelector.getInstance().toLocation(key.getPosition()), EntityType.valueOf(key.getType()));
                             Object armorStand = ReflectionUtil.armorstandCreation(MobSelector.getInstance().toLocation(key.getPosition()), entity, key);
 
-                            if (armorStand != null)
-                            {
+                            if (armorStand != null) {
                                 MobSelector.getInstance().updateCustom(key, armorStand);
                                 Entity armor = (Entity) armorStand;
-                                if (armor.getPassenger() == null && key.getItemId() != null)
-                                {
-                                    Item item = Bukkit.getWorld(key.getPosition().getWorld()).dropItem(armor.getLocation(), new ItemStack(Material.getMaterial(key.getItemId())));
-                                    item.setTicksLived(Integer.MAX_VALUE);
-                                    item.setPickupDelay(Integer.MAX_VALUE);
-                                    armor.setPassenger(item);
+                                if (armor.getPassenger() == null && key.getItemId() != null) {
+                                    Material material = ItemStackBuilder.getMaterialIgnoreVersion(key.getItemName(), key.getItemId());
+                                    if (material != null) {
+                                        Item item = Bukkit.getWorld(key.getPosition().getWorld()).dropItem(armor.getLocation(), new ItemStack(material));
+                                        item.setTicksLived(Integer.MAX_VALUE);
+                                        item.setPickupDelay(Integer.MAX_VALUE);
+                                        armor.setPassenger(item);
+                                    }
                                 }
                             }
 
-                            if (entity instanceof Villager)
-                            {
+                            if (entity instanceof Villager) {
                                 ((Villager) entity).setProfession(Villager.Profession.FARMER);
                             }
 

--- a/cloudnet-api/cloudnet-api-bridge/src/main/java/de/dytanic/cloudnet/bridge/internal/util/ItemStackBuilder.java
+++ b/cloudnet-api/cloudnet-api-bridge/src/main/java/de/dytanic/cloudnet/bridge/internal/util/ItemStackBuilder.java
@@ -4,6 +4,7 @@
 
 package de.dytanic.cloudnet.bridge.internal.util;
 
+import de.dytanic.cloudnet.api.CloudAPI;
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
@@ -14,6 +15,7 @@ import org.bukkit.inventory.meta.SkullMeta;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Level;
 
 /**
  * Created by Tareko on 26.08.2017.
@@ -29,6 +31,9 @@ public class ItemStackBuilder {
         this.itemMeta = itemStack.getItemMeta();
     }
 
+    /**
+     * @deprecated will only work in versions lower than 1.13
+     */
     public ItemStackBuilder(int material)
     {
         this.itemStack = new ItemStack(Material.getMaterial(material));
@@ -41,6 +46,9 @@ public class ItemStackBuilder {
         this.itemMeta = itemStack.getItemMeta();
     }
 
+    /**
+     * @deprecated will only work in versions lower than 1.13
+     */
     public ItemStackBuilder(int material, int amount)
     {
         this.itemStack = new ItemStack(material, amount);
@@ -53,10 +61,37 @@ public class ItemStackBuilder {
         this.itemMeta = itemStack.getItemMeta();
     }
 
+    /**
+     * @deprecated will only work in versions lower than 1.13
+     */
+    @Deprecated
     public ItemStackBuilder(int material, int amount, int sub)
     {
-        this.itemStack = new ItemStack(Material.getMaterial(material), amount, (short) sub);
+        this.itemStack = new ItemStack(material, amount, (short) sub);
         this.itemMeta = itemStack.getItemMeta();
+    }
+
+    /**
+     * Gets a Material whether by name or by id if not used in MC 1.13+
+     *
+     * @param name the materialName of the wanted material or null when the id should be used
+     * @param id the materialId of the wanted material or any other number when the name should be used
+     * @return the material or null if not existing
+     */
+    public static Material getMaterialIgnoreVersion(String name, int id) {
+        if(name == null) {
+            try {
+                return Material.getMaterial(id);
+            } catch (ExceptionInInitializerError | NoSuchMethodError exception) {
+                CloudAPI.getInstance().getLogger().logp(Level.WARNING,
+                        ItemStackBuilder.class.getSimpleName(),
+                        "getMaterialIgnoreVersion",
+                        String.format("Can't get material by id %d! Beginning with MC 1.13 you HAVE to use material names!", id),
+                        exception);
+                return null;
+            }
+        }
+        return Material.getMaterial(name);
     }
 
     public static ItemStackBuilder builder(Material material)
@@ -74,20 +109,33 @@ public class ItemStackBuilder {
         return new ItemStackBuilder(material, amount, sub);
     }
 
+    /**
+     * @deprecated will only work in versions lower than 1.13
+     */
+    @Deprecated
     public static ItemStackBuilder builder(int material)
     {
         return new ItemStackBuilder(material);
     }
 
+    /**
+     * @deprecated will only work in versions lower than 1.13
+     */
+    @Deprecated
     public static ItemStackBuilder builder(int material, int amount)
     {
         return new ItemStackBuilder(material, amount);
     }
 
+    /**
+     * @deprecated will only work in versions lower than 1.13
+     */
+    @Deprecated
     public static ItemStackBuilder builder(int material, int amount, int sub)
     {
         return new ItemStackBuilder(material, amount, sub);
     }
+
 
     public ItemStackBuilder enchantment(Enchantment enchantment, int value)
     {

--- a/cloudnet-api/pom.xml
+++ b/cloudnet-api/pom.xml
@@ -24,12 +24,11 @@
             <id>cloudnet-repo</id>
             <url>https://cloudnetservice.eu/repositories</url>
         </repository>
-        <!-- SpigotMC repository
+        <!-- SpigotMC repository -->
         <repository>
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
-        -->
     </repositories>
 
     <dependencies>
@@ -41,8 +40,8 @@
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
-            <artifactId>spigot <!-- spigot-api --> </artifactId>
-            <version>${dependency.spigot.version} <!-- 1.13-R0.1-SNAPSHOT --> </version>
+            <artifactId>spigot-api</artifactId>
+            <version>${dependency.spigot.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/cloudnet-examples/pom.xml
+++ b/cloudnet-examples/pom.xml
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
+            <artifactId>spigot-api</artifactId>
             <version>${dependency.spigot.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/player/permission/PermissionGroup.java
+++ b/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/player/permission/PermissionGroup.java
@@ -3,8 +3,8 @@ package de.dytanic.cloudnet.lib.player.permission;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by Tareko on 01.06.2017.
@@ -20,9 +20,9 @@ public class PermissionGroup {
     protected int tagId;
     protected int joinPower;
     protected boolean defaultGroup;
-    protected HashMap<String, Boolean> permissions;
-    protected java.util.Map<String, List<String>> serverGroupPermissions;
-    protected java.util.Map<String, Object> options;
-    protected java.util.List<String> implementGroups;
+    protected Map<String, Boolean> permissions;
+    protected Map<String, List<String>> serverGroupPermissions;
+    protected Map<String, Object> options;
+    protected List<String> implementGroups;
 
 }

--- a/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/serverselectors/mob/MobItemLayout.java
+++ b/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/serverselectors/mob/MobItemLayout.java
@@ -12,7 +12,13 @@ import java.util.List;
 @AllArgsConstructor
 public class MobItemLayout implements Cloneable {
 
+    /**
+     * itemIds are not supported in all versions, use {@link MobItemLayout#itemName} instead
+     */
+
+    @Deprecated
     private int itemId;
+    private String itemName;
     private int subId;
     private String display;
     private List<String> lore;
@@ -20,6 +26,6 @@ public class MobItemLayout implements Cloneable {
     @Override
     public MobItemLayout clone()
     {
-        return new MobItemLayout(itemId, subId, display, lore);
+        return new MobItemLayout(itemId, itemName, subId, display, lore);
     }
 }

--- a/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/serverselectors/mob/ServerMob.java
+++ b/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/serverselectors/mob/ServerMob.java
@@ -21,7 +21,12 @@ public class ServerMob implements Nameable {
     protected String name;
     protected String type;
     protected String targetGroup;
+    /**
+     * itemIds are not supported in all versions, use {@link ServerMob#itemName} instead
+     */
+    @Deprecated
     protected Integer itemId;
+    protected String itemName;
     protected Boolean autoJoin;
     protected MobPosition position;
     protected String displayMessage;

--- a/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/serverselectors/sign/SignLayout.java
+++ b/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/serverselectors/sign/SignLayout.java
@@ -14,7 +14,12 @@ public class SignLayout
 
     private String name;
     private String[] signLayout;
-    private int blockId;
+    /**
+     * blockIds are not supported in all versions, use {@link SignLayout#blockName} instead
+     */
+    @Deprecated
+    int blockId;
+    private String blockName;
     private int subId;
 
 }

--- a/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/utility/MapWrapper.java
+++ b/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/utility/MapWrapper.java
@@ -8,6 +8,7 @@ import de.dytanic.cloudnet.lib.NetworkUtils;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Map;
 
 
 public final class MapWrapper {
@@ -16,7 +17,7 @@ public final class MapWrapper {
     {
     }
 
-    public static <K, V> java.util.Map collectionCatcherHashMap(Collection<V> key, Catcher<K, V> catcher)
+    public static <K, V> Map<K, V> collectionCatcherHashMap(Collection<V> key, Catcher<K, V> catcher)
     {
         HashMap<K, V> kvHashMap = new HashMap<>();
         for (V value : key)
@@ -26,10 +27,10 @@ public final class MapWrapper {
         return kvHashMap;
     }
 
-    public static <K, V> java.util.Map filter(java.util.Map<K, V> map, Acceptable<V> acceptable)
+    public static <K, V> Map<K, V> filter(Map<K, V> map, Acceptable<V> acceptable)
     {
-        java.util.Map<K, V> filter = NetworkUtils.newConcurrentHashMap();
-        for (java.util.Map.Entry<K, V> value : map.entrySet())
+        Map<K, V> filter = NetworkUtils.newConcurrentHashMap();
+        for (Map.Entry<K, V> value : map.entrySet())
         {
             if (acceptable.isAccepted(value.getValue()))
             {
@@ -40,9 +41,9 @@ public final class MapWrapper {
     }
 
     @SafeVarargs
-    public static <K, V> java.util.Map valueableHashMap(Return<K, V>... returns)
+    public static <K, V> Map<K, V> valueableHashMap(Return<K, V>... returns)
     {
-        java.util.HashMap<K, V> map = new HashMap<>();
+        HashMap<K, V> map = new HashMap<>();
         for (Return<K, V> kvReturn : returns)
         {
             map.put(kvReturn.getFirst(), kvReturn.getSecond());
@@ -50,10 +51,10 @@ public final class MapWrapper {
         return map;
     }
 
-    public static <K, V, NK, VK> java.util.Map transform(java.util.Map<K, V> values, Catcher<NK, K> keyCatcher, Catcher<VK, V> valueCatcher)
+    public static <K, V, NK, VK> Map<NK, VK> transform(Map<K, V> values, Catcher<NK, K> keyCatcher, Catcher<VK, V> valueCatcher)
     {
-        java.util.Map<NK, VK> nkvkMap = new HashMap<>();
-        for (java.util.Map.Entry<K, V> entry : values.entrySet())
+        Map<NK, VK> nkvkMap = new HashMap<>();
+        for (Map.Entry<K, V> entry : values.entrySet())
         {
             nkvkMap.put(keyCatcher.doCatch(entry.getKey()), valueCatcher.doCatch(entry.getValue()));
         }

--- a/cloudnet-modules/cloudnet-modules-mobs/src/main/java/de/dytanic/cloudnetcore/mobs/config/ConfigMobs.java
+++ b/cloudnet-modules/cloudnet-modules-mobs/src/main/java/de/dytanic/cloudnetcore/mobs/config/ConfigMobs.java
@@ -17,6 +17,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 
 /**
  * Created by Tareko on 21.08.2017.
@@ -25,31 +26,26 @@ public class ConfigMobs implements ILoader<MobConfig> {
 
     private final Path path = Paths.get("local/servermob_config.json");
 
-    public ConfigMobs()
-    {
-        if (!Files.exists(path))
-        {
+    public ConfigMobs() {
+        if (!Files.exists(path)) {
             new Document()
-                    .append("mobConfig", new MobConfig(54, 10, new MobItemLayout(388, 0,
-                                    "§6%server%", Arrays.asList(NetworkUtils.SPACE_STRING, "§e%state%", "§e%online_players% §8/§e%max_players%", "§e%motd%")),
-                                    MapWrapper.valueableHashMap(
-                                            new Return<>(1, new MobItemLayout(160, 15, NetworkUtils.SPACE_STRING, Arrays.asList(NetworkUtils.SPACE_STRING))),
-                                            new Return<>(2, new MobItemLayout(160, 15, NetworkUtils.SPACE_STRING, Arrays.asList(NetworkUtils.SPACE_STRING))),
-                                            new Return<>(3, new MobItemLayout(160, 15, NetworkUtils.SPACE_STRING, Arrays.asList(NetworkUtils.SPACE_STRING))),
-                                            new Return<>(4, new MobItemLayout(160, 15, NetworkUtils.SPACE_STRING, Arrays.asList(NetworkUtils.SPACE_STRING))),
-                                            new Return<>(5, new MobItemLayout(160, 15, NetworkUtils.SPACE_STRING, Arrays.asList(NetworkUtils.SPACE_STRING))),
-                                            new Return<>(6, new MobItemLayout(160, 15, NetworkUtils.SPACE_STRING, Arrays.asList(NetworkUtils.SPACE_STRING))),
-                                            new Return<>(7, new MobItemLayout(160, 15, NetworkUtils.SPACE_STRING, Arrays.asList(NetworkUtils.SPACE_STRING))),
-                                            new Return<>(8, new MobItemLayout(160, 15, NetworkUtils.SPACE_STRING, Arrays.asList(NetworkUtils.SPACE_STRING))),
-                                            new Return<>(9, new MobItemLayout(160, 15, NetworkUtils.SPACE_STRING, Arrays.asList(NetworkUtils.SPACE_STRING))))
-                            )
-                    ).saveAsConfig(path);
+                    .append("mobConfig", new MobConfig(54, 10, new MobItemLayout(388, "EMERALD", 0,
+                            "§6%server%", Arrays.asList(NetworkUtils.SPACE_STRING, "§e%state%", "§e%online_players% §8/§e%max_players%", "§e%motd%")),
+                            MapWrapper.valueableHashMap(
+                                    new Return<>(1, new MobItemLayout(160, "BLACK_STAINED_GLASS_PANE", 15, NetworkUtils.SPACE_STRING, Collections.singletonList(NetworkUtils.SPACE_STRING))),
+                                    new Return<>(2, new MobItemLayout(160, "BLACK_STAINED_GLASS_PANE", 15, NetworkUtils.SPACE_STRING, Collections.singletonList(NetworkUtils.SPACE_STRING))),
+                                    new Return<>(3, new MobItemLayout(160, "BLACK_STAINED_GLASS_PANE", 15, NetworkUtils.SPACE_STRING, Collections.singletonList(NetworkUtils.SPACE_STRING))),
+                                    new Return<>(5, new MobItemLayout(160, "BLACK_STAINED_GLASS_PANE", 15, NetworkUtils.SPACE_STRING, Collections.singletonList(NetworkUtils.SPACE_STRING))),
+                                    new Return<>(6, new MobItemLayout(160, "BLACK_STAINED_GLASS_PANE", 15, NetworkUtils.SPACE_STRING, Collections.singletonList(NetworkUtils.SPACE_STRING))),
+                                    new Return<>(7, new MobItemLayout(160, "BLACK_STAINED_GLASS_PANE", 15, NetworkUtils.SPACE_STRING, Collections.singletonList(NetworkUtils.SPACE_STRING))),
+                                    new Return<>(8, new MobItemLayout(160, "BLACK_STAINED_GLASS_PANE", 15, NetworkUtils.SPACE_STRING, Collections.singletonList(NetworkUtils.SPACE_STRING))),
+                                    new Return<>(9, new MobItemLayout(160, "BLACK_STAINED_GLASS_PANE", 15, NetworkUtils.SPACE_STRING, Collections.singletonList(NetworkUtils.SPACE_STRING))))
+                    )).saveAsConfig(path);
         }
     }
 
     @Override
-    public MobConfig load()
-    {
+    public MobConfig load() {
         return Document.loadDocument(path).getObject("mobConfig", new TypeToken<MobConfig>() {
         }.getType());
     }

--- a/cloudnet-modules/cloudnet-modules-permission/src/main/java/de/dytanic/cloudnetcore/permissions/config/ConfigPermissions.java
+++ b/cloudnet-modules/cloudnet-modules-permission/src/main/java/de/dytanic/cloudnetcore/permissions/config/ConfigPermissions.java
@@ -48,7 +48,7 @@ public class ConfigPermissions {
                         0,
                         true,
                         new HashMap<>(),
-                        MapWrapper.valueableHashMap(new Return<String, List>("Lobby", Arrays.asList("test.permission.for.group.Lobby"))),
+                        MapWrapper.valueableHashMap(new Return<>("Lobby", Arrays.asList("test.permission.for.group.Lobby"))),
                         new HashMap<>(),
                         new ArrayList<>()
                 );
@@ -62,8 +62,8 @@ public class ConfigPermissions {
                         0,
                         100,
                         false,
-                        (HashMap) MapWrapper.valueableHashMap(new Return<>("*", true)),
-                        MapWrapper.valueableHashMap(new Return<String, java.util.List>("Lobby", Arrays.asList("test.permission.for.group.Lobby"))),
+                        MapWrapper.valueableHashMap(new Return<>("*", true)),
+                        MapWrapper.valueableHashMap(new Return<>("Lobby", Arrays.asList("test.permission.for.group.Lobby"))),
                         new HashMap<>(),
                         new ArrayList<>()
                 );

--- a/cloudnet-modules/cloudnet-modules-signs/src/main/java/de/dytanic/cloudnetcore/signs/config/ConfigSignLayout.java
+++ b/cloudnet-modules/cloudnet-modules-signs/src/main/java/de/dytanic/cloudnetcore/signs/config/ConfigSignLayout.java
@@ -33,46 +33,46 @@ public class ConfigSignLayout {
                     Arrays.asList(new SignGroupLayouts(
                             "default",
                             Arrays.asList(
-                                    new SignLayout("empty", new String[]{"%server%", "&e%state%", "%online_players%/%max_players%", "%motd%"}, 159, 0),
-                                    new SignLayout("online", new String[]{"%server%", "&e%state%", "%online_players%/%max_players%", "%motd%"}, 159, 0),
-                                    new SignLayout("full", new String[]{"%server%", "&ePREMIUM", "%online_players%/%max_players%", "%motd%"}, 159, 0),
-                                    new SignLayout("maintenance", new String[]{"§8§m---------", "maintenance", "§cmode", "§8§m---------"}, 159, 0)
+                                    new SignLayout("empty", new String[]{"%server%", "&e%state%", "%online_players%/%max_players%", "%motd%"}, 159, "BROWN_TERRACOTTA", 0),
+                                    new SignLayout("online", new String[]{"%server%", "&e%state%", "%online_players%/%max_players%", "%motd%"}, 159, "BROWN_TERRACOTTA", 0),
+                                    new SignLayout("full", new String[]{"%server%", "&ePREMIUM", "%online_players%/%max_players%", "%motd%"}, 159, "BROWN_TERRACOTTA", 0),
+                                    new SignLayout("maintenance", new String[]{"§8§m---------", "maintenance", "§cmode", "§8§m---------"}, 159, "BROWN_TERRACOTTA", 0)
                             )
                     ))
                     , new SearchingAnimation(33, 11, Arrays.asList(
-                    new SignLayout("loading1", new String[]{"", "server loads...", "o                ", ""}, 159, 14),
-                    new SignLayout("loading2", new String[]{"", "server loads...", " o               ", ""}, 159, 14),
-                    new SignLayout("loading3", new String[]{"", "server loads...", "  o              ", ""}, 159, 14),
-                    new SignLayout("loading4", new String[]{"", "server loads...", "   o             ", ""}, 159, 14),
-                    new SignLayout("loading5", new String[]{"", "server loads...", "    o            ", ""}, 159, 14),
-                    new SignLayout("loading6", new String[]{"", "server loads...", "o    o           ", ""}, 159, 14),
-                    new SignLayout("loading7", new String[]{"", "server loads...", " o    o          ", ""}, 159, 14),
-                    new SignLayout("loading8", new String[]{"", "server loads...", "  o    o         ", ""}, 159, 14),
-                    new SignLayout("loading9", new String[]{"", "server loads...", "   o    o        ", ""}, 159, 14),
-                    new SignLayout("loading10", new String[]{"", "server loads...", "    o    o       ", ""}, 159, 14),
-                    new SignLayout("loading11", new String[]{"", "server loads...", "o    o    o      ", ""}, 159, 14),
-                    new SignLayout("loading12", new String[]{"", "server loads...", " o    o    o     ", ""}, 159, 14),
-                    new SignLayout("loading13", new String[]{"", "server loads...", "  o    o    o    ", ""}, 159, 14),
-                    new SignLayout("loading14", new String[]{"", "server loads...", "   o    o    o   ", ""}, 159, 14),
-                    new SignLayout("loading15", new String[]{"", "server loads...", "    o    o    o  ", ""}, 159, 14),
-                    new SignLayout("loading16", new String[]{"", "server loads...", "o    o    o    o ", ""}, 159, 14),
-                    new SignLayout("loading17", new String[]{"", "server loads...", " o    o    o    o", ""}, 159, 14),
-                    new SignLayout("loading18", new String[]{"", "server loads...", "  o    o    o    ", ""}, 159, 14),
-                    new SignLayout("loading19", new String[]{"", "server loads...", "   o    o    o   ", ""}, 159, 14),
-                    new SignLayout("loading20", new String[]{"", "server loads...", "    o    o    o   ", ""}, 159, 14),
-                    new SignLayout("loading21", new String[]{"", "server loads...", "     o    o    o ", ""}, 159, 14),
-                    new SignLayout("loading22", new String[]{"", "server loads...", "      o    o    o", ""}, 159, 14),
-                    new SignLayout("loading23", new String[]{"", "server loads...", "       o    o    ", ""}, 159, 14),
-                    new SignLayout("loading24", new String[]{"", "server loads...", "        o    o   ", ""}, 159, 14),
-                    new SignLayout("loading25", new String[]{"", "server loads...", "         o    o  ", ""}, 159, 14),
-                    new SignLayout("loading26", new String[]{"", "server loads...", "          o    o ", ""}, 159, 14),
-                    new SignLayout("loading27", new String[]{"", "server loads...", "           o    o", ""}, 159, 14),
-                    new SignLayout("loading28", new String[]{"", "server loads...", "            o    ", ""}, 159, 14),
-                    new SignLayout("loading29", new String[]{"", "server loads...", "             o   ", ""}, 159, 14),
-                    new SignLayout("loading30", new String[]{"", "server loads...", "              o  ", ""}, 159, 14),
-                    new SignLayout("loading31", new String[]{"", "server loads...", "               o ", ""}, 159, 14),
-                    new SignLayout("loading32", new String[]{"", "server loads...", "                o", ""}, 159, 14),
-                    new SignLayout("loading33", new String[]{"", "server loads...", "                 ", ""}, 159, 14)
+                    new SignLayout("loading1", new String[]{"", "server loads...", "o                ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading2", new String[]{"", "server loads...", " o               ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading3", new String[]{"", "server loads...", "  o              ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading4", new String[]{"", "server loads...", "   o             ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading5", new String[]{"", "server loads...", "    o            ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading6", new String[]{"", "server loads...", "o    o           ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading7", new String[]{"", "server loads...", " o    o          ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading8", new String[]{"", "server loads...", "  o    o         ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading9", new String[]{"", "server loads...", "   o    o        ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading10", new String[]{"", "server loads...", "    o    o       ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading11", new String[]{"", "server loads...", "o    o    o      ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading12", new String[]{"", "server loads...", " o    o    o     ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading13", new String[]{"", "server loads...", "  o    o    o    ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading14", new String[]{"", "server loads...", "   o    o    o   ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading15", new String[]{"", "server loads...", "    o    o    o  ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading16", new String[]{"", "server loads...", "o    o    o    o ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading17", new String[]{"", "server loads...", " o    o    o    o", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading18", new String[]{"", "server loads...", "  o    o    o    ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading19", new String[]{"", "server loads...", "   o    o    o   ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading20", new String[]{"", "server loads...", "    o    o    o   ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading21", new String[]{"", "server loads...", "     o    o    o ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading22", new String[]{"", "server loads...", "      o    o    o", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading23", new String[]{"", "server loads...", "       o    o    ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading24", new String[]{"", "server loads...", "        o    o   ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading25", new String[]{"", "server loads...", "         o    o  ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading26", new String[]{"", "server loads...", "          o    o ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading27", new String[]{"", "server loads...", "           o    o", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading28", new String[]{"", "server loads...", "            o    ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading29", new String[]{"", "server loads...", "             o   ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading30", new String[]{"", "server loads...", "              o  ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading31", new String[]{"", "server loads...", "               o ", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading32", new String[]{"", "server loads...", "                o", ""}, 159, "BROWN_TERRACOTTA", 14),
+                    new SignLayout("loading33", new String[]{"", "server loads...", "                 ", ""}, 159, "BROWN_TERRACOTTA", 14)
             )))).saveAsConfig(path);
         }
     }
@@ -128,7 +128,7 @@ public class ConfigSignLayout {
                 });
                 if (signLayout == null)
                 {
-                    groupLayouts.getLayouts().add(new SignLayout("empty", new String[]{"%server%", "&6%state%", "%online_players%/%max_players%", "%motd%"}, 159, 1));
+                    groupLayouts.getLayouts().add(new SignLayout("empty", new String[]{"%server%", "&6%state%", "%online_players%/%max_players%", "%motd%"}, 159, "BROWN_TERRACOTTA", 1));
                     injectable = true;
                 }
             }

--- a/cloudnet-tools/pom.xml
+++ b/cloudnet-tools/pom.xml
@@ -24,6 +24,11 @@
             <id>cloudnet-repo</id>
             <url>https://cloudnetservice.eu/repositories</url>
         </repository>
+        <!-- SpigotMC repository -->
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -35,7 +40,7 @@
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
+            <artifactId>spigot-api</artifactId>
             <version>${dependency.spigot.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <dependency.jopt-simple.version>5.0.4</dependency.jopt-simple.version>
         <dependecy.snakeyaml.version>1.24</dependecy.snakeyaml.version>
         <dependency.bungeecord.version>1.8-1.12</dependency.bungeecord.version>
-        <dependency.spigot.version>1.8.8</dependency.spigot.version>
+        <dependency.spigot.version>1.8.8-R0.1-SNAPSHOT</dependency.spigot.version>
         <dependency.vaultapi.version>1.7</dependency.vaultapi.version>
         <dependency.typetools.version>0.6.1</dependency.typetools.version>
         <!-- test dependencies -->


### PR DESCRIPTION
To be able to fix this issue, I added a materialName-string to every config-object containing materialIds and deprecated these ids. Users below the Minecraft version 1.13 will still be able to use materialIds for both Sign- and MobSelector, although they are not recommended. Users of Minecraft 1.13 will just have to delete the config and database of Sign- and MobSelector, so they will contain the new materialName property. 
In MC 1.13+ the backblocks of the signs won't work, because the api doesn't provide enough info of the sign.
I also removed the spigot 1.8.8 dependency from the cloudAPI and added the 1.8.8 spigot-api.