### PR TITLE
Fix Travis-CI failing to install openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: java
 dist: bionic
-jdk:
-  - openjdk8
 sudo: false
 notifications:
   email: false  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: java
+dist: bionic
 jdk:
   - openjdk8
 sudo: false
-addons:
-  apt:
-    packages:
-      - openjdk8
 notifications:
   email: false  


### PR DESCRIPTION
I tried to fix Travis-CI.
It builds with JDK 11 now and the docs are wrong, so there's that.

Feel free to merge whenever you want.