### PR TITLE
Fix Bungee's logger that automatically uses "all logging"

### DIFF
--- a/cloudnet-api/cloudnet-api-bridge/src/main/java/de/dytanic/cloudnet/bridge/ProxiedBootstrap.java
+++ b/cloudnet-api/cloudnet-api-bridge/src/main/java/de/dytanic/cloudnet/bridge/ProxiedBootstrap.java
@@ -21,6 +21,7 @@ import net.md_5.bungee.api.plugin.Plugin;
 
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 
 /**
  * Created by Tareko on 17.08.2017.
@@ -37,6 +38,7 @@ public class ProxiedBootstrap extends Plugin {
                 getProxy().stop("CloudNet-Stop!");
             }
         });
+        getLogger().setLevel(Level.INFO);
         CloudAPI.getInstance().setLogger(getLogger());
     }
 


### PR DESCRIPTION
Bungeecord automatically log ALL messages to the log file.
This creates large files that are filled with unnecessary information.

This PR fixes this issue by setting the level to INFO upon start.