### PR TITLE
Fix security with Guava 17.0

### DIFF
--- a/cloudnet-api/pom.xml
+++ b/cloudnet-api/pom.xml
@@ -43,6 +43,14 @@
             <artifactId>spigot-api</artifactId>
             <version>${dependency.spigot.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <!-- See https://github.com/CloudNetService/CloudNet/issues/141
+                     for the reason of this exclusion. -->
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/cloudnet-examples/pom.xml
+++ b/cloudnet-examples/pom.xml
@@ -47,6 +47,14 @@
             <artifactId>spigot-api</artifactId>
             <version>${dependency.spigot.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <!-- See https://github.com/CloudNetService/CloudNet/issues/141
+                     for the reason of this exclusion. -->
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/cloudnet-tools/pom.xml
+++ b/cloudnet-tools/pom.xml
@@ -43,6 +43,14 @@
             <artifactId>spigot-api</artifactId>
             <version>${dependency.spigot.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <!-- See https://github.com/CloudNetService/CloudNet/issues/141
+                     for the reason of this exclusion. -->
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This fixes #141 by excluding this dependency from the project.
When Guava is needed, it should manually be added with the latest version.

We can't fix the security issue in Spigot and we should make sure, that users of CloudNet know about this vulnerability.