### PR TITLE
Use the given serverId in ServiceId#toString

### DIFF
--- a/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/service/ServiceId.java
+++ b/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/service/ServiceId.java
@@ -70,9 +70,8 @@ public final class ServiceId {
     }
 
     @Override
-    public String toString()
-    {
-        return group + "-" + id + "#" + uniqueId.toString();
+    public String toString() {
+        return this.serverId + "#" + this.uniqueId.toString();
     }
 
 }


### PR DESCRIPTION
With that ServiceId#toString also uses the splitter specified in the config of the Master