### PR TITLE
Fixed twice server/proxy group imports on wrapper startup

### DIFF
--- a/cloudnet-core/src/main/java/de/dytanic/cloudnetcore/network/CloudNetClient.java
+++ b/cloudnet-core/src/main/java/de/dytanic/cloudnetcore/network/CloudNetClient.java
@@ -48,7 +48,6 @@ public class CloudNetClient extends SimpleChannelInboundHandler {
             CloudNet.getInstance().getDbHandlers().getWrapperSessionDatabase().addSession(new WrapperSession(UUID.randomUUID(),
                                                                                                              ((Wrapper) networkComponent).getNetworkInfo(),
                                                                                                              System.currentTimeMillis()));
-            ((Wrapper) networkComponent).updateWrapper();
         }
 
         CloudNetwork cloudNetwork = CloudNet.getInstance().getNetworkManager().newCloudNetwork();


### PR DESCRIPTION
Removed update on connect because it is already updated when the wrapper first sends the PacketOutUpdateWrapper packet