### PR TITLE
Remove double "." when getting craft class

### DIFF
--- a/cloudnet-api/cloudnet-api-bridge/src/main/java/de/dytanic/cloudnet/bridge/internal/util/ReflectionUtil.java
+++ b/cloudnet-api/cloudnet-api-bridge/src/main/java/de/dytanic/cloudnet/bridge/internal/util/ReflectionUtil.java
@@ -25,7 +25,7 @@ public final class ReflectionUtil {
             return Class.forName("org.bukkit.craftbukkit." + version + suffix);
         } catch (Exception ex) {
             try {
-                return Class.forName("org.bukkit.craftbukkit." + suffix);
+                return Class.forName("org.bukkit.craftbukkit" + suffix);
             } catch (ClassNotFoundException e) {
             }
         }


### PR DESCRIPTION
This PR removes a second "." char, this should be not a problem when using "normal" spigot, but if you compile spigot yourself and don't move the classes from org.bukkit.craftbukkit to org.bukkit.craftbukkit.VERSION, this issue occurred.