### PR TITLE
Fixed local wrapper spigot installer

### DIFF
--- a/cloudnet-cord/cloudnet-setup/src/main/java/de/dytanic/cloudnet/setup/spigot/PaperBuilder.java
+++ b/cloudnet-cord/cloudnet-setup/src/main/java/de/dytanic/cloudnet/setup/spigot/PaperBuilder.java
@@ -30,7 +30,7 @@ public final class PaperBuilder {
      *
      * @param reader Read the answer from console
      */
-    public static void start(ConsoleReader reader, Path outputPath) {
+    public static boolean start(ConsoleReader reader, Path outputPath) {
         try {
             System.out.println("Fetch Versions");
             URLConnection connection = new URL(apiProjectUrl).openConnection();
@@ -56,7 +56,7 @@ public final class PaperBuilder {
                 String finalAnswer = name;
                 if (Arrays.stream(paperMCProject.getVersions()).anyMatch(e -> e.equalsIgnoreCase(finalAnswer))) {
                     answer = name;
-                    buildPaperVersion(answer, outputPath);
+                    return buildPaperVersion(answer, outputPath);
                 } else if (Arrays.stream(paperMCProject.getVersions()).noneMatch(e -> e.equalsIgnoreCase(finalAnswer))) {
                     System.out.println("This version does not exist!");
                 }
@@ -64,6 +64,7 @@ public final class PaperBuilder {
         } catch (Exception e) {
             e.printStackTrace();
         }
+        return false;
     }
 
     /**
@@ -73,7 +74,7 @@ public final class PaperBuilder {
      *
      * @throws Exception If a connection error or something
      */
-    private static void buildPaperVersion(String version, Path outputPath) throws Exception {
+    private static boolean buildPaperVersion(String version, Path outputPath) throws Exception {
         System.out.println(String.format("Fetching build %s", version));
         URLConnection connection = new URL(String.format(API_PROJECT_VERSION_URL, version)).openConnection();
         connection.setRequestProperty("User-Agent",
@@ -94,6 +95,7 @@ public final class PaperBuilder {
         File paperclip = new File(buildFolder, "paperclip.jar");
         if (!paperclip.exists()) {
             runPaperClip(connection, buildFolder, paperclip, outputPath);
+            return true;
         } else {
             File[] paperclips = buildFolder.listFiles(pathname -> pathname.getName().startsWith("paper"));
             if (Objects.requireNonNull(paperclips).length > 0) {
@@ -103,16 +105,18 @@ public final class PaperBuilder {
                     Files.copy(new FileInputStream(Objects.requireNonNull(paperclips)[0]),
                                outputPath,
                                StandardCopyOption.REPLACE_EXISTING);
+                    return true;
                 } catch (IOException e) {
                     e.printStackTrace();
+                    return false;
                 }
             } else {
                 SpigotBuilder.deleteBuildFolder(buildFolder);
                 runPaperClip(connection, buildFolder, paperclip, outputPath);
+                return true;
             }
 
         }
-
     }
 
     /**

--- a/cloudnet-cord/cloudnet-setup/src/main/java/de/dytanic/cloudnet/setup/spigot/PaperBuilder.java
+++ b/cloudnet-cord/cloudnet-setup/src/main/java/de/dytanic/cloudnet/setup/spigot/PaperBuilder.java
@@ -97,12 +97,13 @@ public final class PaperBuilder {
             runPaperClip(connection, buildFolder, paperclip, outputPath);
             return true;
         } else {
-            File[] paperclips = buildFolder.listFiles(pathname -> pathname.getName().startsWith("paper"));
-            if (Objects.requireNonNull(paperclips).length > 0) {
+            File cacheFolder = new File(buildFolder, "cache");
+            File[] patchedFiles = cacheFolder.listFiles(pathname -> pathname.getName().startsWith("patched"));
+            if (Objects.requireNonNull(patchedFiles).length > 0) {
                 System.out.println("Skipping build");
                 System.out.println("Copying spigot.jar");
                 try {
-                    Files.copy(new FileInputStream(Objects.requireNonNull(paperclips)[0]),
+                    Files.copy(new FileInputStream(Objects.requireNonNull(patchedFiles)[0]),
                                outputPath,
                                StandardCopyOption.REPLACE_EXISTING);
                     return true;
@@ -136,10 +137,9 @@ public final class PaperBuilder {
         exec = Runtime.getRuntime().exec("java -jar paperclip.jar", null, buildFolder);
         printProcessOutputToConsole(exec);
 
-        Files.copy(new FileInputStream(Objects.requireNonNull(buildFolder.listFiles(pathname -> pathname.getName()
-                                                                                                        .startsWith("paperclip")))[0]),
-                   outputPath,
-                   StandardCopyOption.REPLACE_EXISTING);
+        File cacheFolder = new File(buildFolder, "cache");
+        File[] patchedFiles = cacheFolder.listFiles(pathname -> pathname.getName().startsWith("patched"));
+        Files.copy(new FileInputStream(Objects.requireNonNull(patchedFiles)[0]), outputPath, StandardCopyOption.REPLACE_EXISTING);
     }
 
     /**

--- a/cloudnet-cord/cloudnet-setup/src/main/java/de/dytanic/cloudnet/setup/spigot/SetupSpigotVersion.java
+++ b/cloudnet-cord/cloudnet-setup/src/main/java/de/dytanic/cloudnet/setup/spigot/SetupSpigotVersion.java
@@ -15,6 +15,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 /**
  * Created by Tareko on 25.05.2017.
@@ -23,22 +24,21 @@ public class SetupSpigotVersion implements Consumer<ConsoleReader> {
 
     private Path target;
 
-    private final Consumer<String> download = new Consumer<String>() {
-        @Override
-        public void accept(String url) {
-            try {
-                System.out.println("Downloading spigot.jar...");
-                URLConnection connection = new URL(url).openConnection();
-                connection.setRequestProperty("User-Agent",
-                                              "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.95 Safari/537.11");
-                connection.connect();
-                try (InputStream inputStream = connection.getInputStream()) {
-                    Files.copy(inputStream, SetupSpigotVersion.this.getTarget(), StandardCopyOption.REPLACE_EXISTING);
-                }
-                System.out.println("Download was successfully completed!");
-            } catch (Exception e) {
-                e.printStackTrace();
+    private final Predicate<String> download = url -> {
+        try {
+            System.out.println("Downloading spigot.jar...");
+            URLConnection connection = new URL(url).openConnection();
+            connection.setRequestProperty("User-Agent",
+                                          "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.95 Safari/537.11");
+            connection.connect();
+            try (InputStream inputStream = connection.getInputStream()) {
+                Files.copy(inputStream, SetupSpigotVersion.this.getTarget(), StandardCopyOption.REPLACE_EXISTING);
             }
+            System.out.println("Download was successfully completed!");
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
         }
     };
 
@@ -51,13 +51,71 @@ public class SetupSpigotVersion implements Consumer<ConsoleReader> {
     public void accept(ConsoleReader reader) {
         System.out.println("No spigot.jar has been found!");
 
-        System.out.println("Choose a minecraft server version [\"paper\", \"spigot\", \"buildtools\"]");
+        String spigotType;
+        do {
+            System.out.println("Choose a minecraft server version [\"paper\", \"spigot\", \"buildtools\"]");
+            spigotType = System.getProperty("spigot-type") != null ? System.getProperty("spigot-type") : this.askForServerType(reader);
+        } while (!this.install(reader, spigotType));
+    }
 
-        String answer = null;
-
-        if (System.getProperty("spigot-type") != null) {
-            answer = System.getProperty("spigot-type");
+    private boolean install(ConsoleReader reader, String spigotType) {
+        switch (spigotType) {
+            case "spigot":
+                return this.installSpigot(reader);
+            case "buildtools":
+                return SpigotBuilder.start(reader, this.getTarget());
+            case "paper":
+                return PaperBuilder.start(reader, this.getTarget());
         }
+        return false;
+    }
+
+    private boolean installSpigot(ConsoleReader reader) {
+        System.out.println(
+            "Choose a Spigot version [\"1.7.10\", \"1.8.8\", \"1.9.4\", \"1.10.2\", \"1.11.2\", \"1.12.2\", \"1.13\", \"1.13.1\", \"1.13.2\", \"1.14\", \"1.14.1\", \"1.14.2\", \"1.14.3\", \"1.14.4\"]");
+        while (true) {
+            try {
+                switch (reader.readLine().toLowerCase()) {
+                    case "1.7.10":
+                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.7.10-SNAPSHOT-b1657.jar");
+                    case "1.8.8":
+                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.8.8-R0.1-SNAPSHOT-latest.jar");
+                    case "1.9.4":
+                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.9.4-R0.1-SNAPSHOT-latest.jar");
+                    case "1.10.2":
+                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.10.2-R0.1-SNAPSHOT-latest.jar");
+                    case "1.11.2":
+                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.11.2.jar");
+                    case "1.12.2":
+                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.12.2.jar");
+                    case "1.13":
+                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.13.jar");
+                    case "1.13.1":
+                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.13.1.jar");
+                    case "1.13.2":
+                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.13.2.jar");
+                    case "1.14":
+                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.14.jar");
+                    case "1.14.1":
+                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.14.1.jar");
+                    case "1.14.2":
+                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.14.2.jar");
+                    case "1.14.3":
+                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.14.3.jar");
+                    case "1.14.4":
+                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.14.4.jar");
+                    default:
+                        System.out.println("This version is not supported!");
+                        break;
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private String askForServerType(ConsoleReader reader) {
+        String answer = null;
 
         String input;
 
@@ -83,73 +141,8 @@ public class SetupSpigotVersion implements Consumer<ConsoleReader> {
                 ex.printStackTrace();
             }
         }
-        if (System.getProperty("spigot-version") != null) {
-            answer = System.getProperty("spigot-version");
-        }
-        switch (answer) {
-            case "spigot":
-                System.out.println(
-                    "Choose a Spigot version [\"1.7.10\", \"1.8.8\", \"1.9.4\", \"1.10.2\", \"1.11.2\", \"1.12.2\", \"1.13\", \"1.13.1\", \"1.13.2\", \"1.14\", \"1.14.1\", \"1.14.2\", \"1.14.3\", \"1.14.4\"]");
-                while (true) {
-                    try {
-                        switch (reader.readLine().toLowerCase()) {
-                            case "1.7.10":
-                                download.accept("https://cdn.getbukkit.org/spigot/spigot-1.7.10-SNAPSHOT-b1657.jar");
-                                return;
-                            case "1.8.8":
-                                download.accept("https://cdn.getbukkit.org/spigot/spigot-1.8.8-R0.1-SNAPSHOT-latest.jar");
-                                return;
-                            case "1.9.4":
-                                download.accept("https://cdn.getbukkit.org/spigot/spigot-1.9.4-R0.1-SNAPSHOT-latest.jar");
-                                return;
-                            case "1.10.2":
-                                download.accept("https://cdn.getbukkit.org/spigot/spigot-1.10.2-R0.1-SNAPSHOT-latest.jar");
-                                return;
-                            case "1.11.2":
-                                download.accept("https://cdn.getbukkit.org/spigot/spigot-1.11.2.jar");
-                                return;
-                            case "1.12.2":
-                                download.accept("https://cdn.getbukkit.org/spigot/spigot-1.12.2.jar");
-                                return;
-                            case "1.13":
-                                download.accept("https://cdn.getbukkit.org/spigot/spigot-1.13.jar");
-                                return;
-                            case "1.13.1":
-                                download.accept("https://cdn.getbukkit.org/spigot/spigot-1.13.1.jar");
-                                return;
-                            case "1.13.2":
-                                download.accept("https://cdn.getbukkit.org/spigot/spigot-1.13.2.jar");
-                                return;
-                            case "1.14":
-                                download.accept("https://cdn.getbukkit.org/spigot/spigot-1.14.jar");
-                                return;
-                            case "1.14.1":
-                                download.accept("https://cdn.getbukkit.org/spigot/spigot-1.14.1.jar");
-                                return;
-                            case "1.14.2":
-                                download.accept("https://cdn.getbukkit.org/spigot/spigot-1.14.2.jar");
-                                return;
-                            case "1.14.3":
-                                download.accept("https://cdn.getbukkit.org/spigot/spigot-1.14.3.jar");
-                                return;
-                            case "1.14.4":
-                                download.accept("https://cdn.getbukkit.org/spigot/spigot-1.14.4.jar");
-                                return;
-                            default:
-                                System.out.println("This version is not supported!");
-                                break;
-                        }
-                    } catch (IOException e) {
-                        e.printStackTrace();
-                    }
-                }
-            case "buildtools":
-                SpigotBuilder.start(reader, this.getTarget());
-                break;
-            case "paper":
-                PaperBuilder.start(reader, this.getTarget());
-                break;
-        }
+
+        return answer;
     }
 
     public Path getTarget() {

--- a/cloudnet-cord/cloudnet-setup/src/main/java/de/dytanic/cloudnet/setup/spigot/SetupSpigotVersion.java
+++ b/cloudnet-cord/cloudnet-setup/src/main/java/de/dytanic/cloudnet/setup/spigot/SetupSpigotVersion.java
@@ -33,7 +33,7 @@ public class SetupSpigotVersion implements Consumer<ConsoleReader> {
                                               "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.95 Safari/537.11");
                 connection.connect();
                 try (InputStream inputStream = connection.getInputStream()) {
-                    Files.copy(inputStream, target != null ? target : Paths.get("local/spigot.jar"), StandardCopyOption.REPLACE_EXISTING);
+                    Files.copy(inputStream, SetupSpigotVersion.this.getTarget(), StandardCopyOption.REPLACE_EXISTING);
                 }
                 System.out.println("Download was successfully completed!");
             } catch (Exception e) {
@@ -144,12 +144,16 @@ public class SetupSpigotVersion implements Consumer<ConsoleReader> {
                     }
                 }
             case "buildtools":
-                SpigotBuilder.start(reader);
+                SpigotBuilder.start(reader, this.getTarget());
                 break;
             case "paper":
-                PaperBuilder.start(reader);
+                PaperBuilder.start(reader, this.getTarget());
                 break;
         }
+    }
+
+    public Path getTarget() {
+        return this.target != null ? this.target : Paths.get("local/spigot.jar");
     }
 
     public void setTarget(Path target) {

--- a/cloudnet-cord/cloudnet-setup/src/main/java/de/dytanic/cloudnet/setup/spigot/SpigotBuilder.java
+++ b/cloudnet-cord/cloudnet-setup/src/main/java/de/dytanic/cloudnet/setup/spigot/SpigotBuilder.java
@@ -28,7 +28,7 @@ public final class SpigotBuilder {
      *
      * @param reader to read the answer
      */
-    public static void start(final ConsoleReader reader) {
+    public static void start(final ConsoleReader reader, Path outputPath) {
         System.out.println("Fetching Spigot versions");
         List<String> versions = loadVersions();
         System.out.println("Available Spigot versions:");
@@ -47,7 +47,7 @@ public final class SpigotBuilder {
             String finalAnswer = name;
             if (versions.stream().anyMatch(e -> e.equalsIgnoreCase(finalAnswer))) {
                 answer = name;
-                buildSpigot(finalAnswer);
+                buildSpigot(finalAnswer, outputPath);
             } else if (versions.stream().noneMatch(e -> e.equalsIgnoreCase(finalAnswer))) {
                 System.out.println("This version does not exist!");
             }
@@ -83,7 +83,7 @@ public final class SpigotBuilder {
      *
      * @param version the version of spigot
      */
-    private static void buildSpigot(final String version) {
+    private static void buildSpigot(final String version, Path outputPath) {
         File builder = new File("local/builder/spigot");
         File buildFolder = new File(builder, version);
         try {
@@ -93,7 +93,7 @@ public final class SpigotBuilder {
         }
         File buildTools = new File(buildFolder, "buildtools.jar");
         if (!buildTools.exists()) {
-            runBuildTools(version, buildFolder, buildTools);
+            runBuildTools(version, buildFolder, buildTools, outputPath);
         } else {
             if (Objects.requireNonNull(buildFolder.listFiles(pathname -> pathname.getName().startsWith("spigot-"))).length > 0) {
                 System.out.println("Skipping build");
@@ -101,13 +101,13 @@ public final class SpigotBuilder {
                 try {
                     Files.copy(new FileInputStream(Objects.requireNonNull(buildFolder.listFiles(pathname -> pathname.getName()
                                                                                                                     .startsWith("spigot-")))[0]),
-                               Paths.get("local/spigot.jar"),
+                               outputPath,
                                StandardCopyOption.REPLACE_EXISTING);
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
             } else {
-                runBuildTools(version, buildFolder, buildTools);
+                runBuildTools(version, buildFolder, buildTools, outputPath);
             }
         }
 
@@ -120,7 +120,7 @@ public final class SpigotBuilder {
      * @param buildFolder the folder in there are build
      * @param buildTools  the path of the build tools
      */
-    private static void runBuildTools(String version, File buildFolder, File buildTools) {
+    private static void runBuildTools(String version, File buildFolder, File buildTools, Path outputPath) {
         try {
             long startTime = System.currentTimeMillis();
             Files.createDirectories(buildFolder.toPath());
@@ -139,7 +139,7 @@ public final class SpigotBuilder {
             if (Objects.requireNonNull(buildFolder.listFiles(pathname -> pathname.getName().startsWith("spigot-"))).length > 0) {
                 Files.copy(new FileInputStream(Objects.requireNonNull(buildFolder.listFiles(pathname -> pathname.getName()
                                                                                                                 .startsWith("spigot-")))[0]),
-                           Paths.get("local/spigot.jar"),
+                           outputPath,
                            StandardCopyOption.REPLACE_EXISTING);
                 long endTime = System.currentTimeMillis();
                 long minutes = ((endTime - startTime) / 1000) / 60;
@@ -147,7 +147,7 @@ public final class SpigotBuilder {
                 System.out.printf("Total Build Time %dMin %dSec\n", minutes, seconds);
             } else {
                 deleteBuildFolder(buildFolder);
-                buildSpigot(version);
+                buildSpigot(version, outputPath);
             }
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
Copy the generated spigot.jar after the build process to wrapper/local/spigot.jar and not to local/spigot.jar, which caused problems with the local wrapper.