### PR TITLE
Remove double "." when getting nms class

### DIFF
--- a/cloudnet-api/cloudnet-api-bridge/src/main/java/de/dytanic/cloudnet/bridge/internal/util/ReflectionUtil.java
+++ b/cloudnet-api/cloudnet-api-bridge/src/main/java/de/dytanic/cloudnet/bridge/internal/util/ReflectionUtil.java
@@ -46,7 +46,7 @@ public final class ReflectionUtil {
             return Class.forName("net.minecraft.server." + version + suffix);
         } catch (Exception ex) {
             try {
-                return Class.forName("net.minecraft.server." + suffix);
+                return Class.forName("net.minecraft.server" + suffix);
             } catch (ClassNotFoundException e) {
             }
         }


### PR DESCRIPTION
This PR removes a second "." char, this should be not a problem when using "normal" spigot, but if you compile spigot yourself and don't move the classes from net.minecraft.server to net.minecraft.server.VERSION, this issue occurred.