### PR TITLE
Protection against arbitrary file write during archive extraction ("Zip Slip")

### DIFF
--- a/cloudnet-core/src/main/java/de/dytanic/cloudnetcore/web/api/v1/WebsiteDeployment.java
+++ b/cloudnet-core/src/main/java/de/dytanic/cloudnetcore/web/api/v1/WebsiteDeployment.java
@@ -15,6 +15,7 @@ import io.netty.handler.codec.http.*;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -136,6 +137,11 @@ public class WebsiteDeployment extends MethodWebHandlerAdapter {
 
     private void extractEntry(ZipFile zipFile, ZipEntry entry, String destDir) throws IOException {
         File file = new File(destDir, entry.getName());
+
+        if (!file.toPath().normalize().startsWith(Paths.get(destDir))) {
+            return;
+        }
+
         final byte[] BUFFER = new byte[0xFFFF];
 
         if (entry.isDirectory()) {

--- a/cloudnet-wrapper/src/main/java/de/dytanic/cloudnetwrapper/network/packet/in/PacketInCreateTemplate.java
+++ b/cloudnet-wrapper/src/main/java/de/dytanic/cloudnetwrapper/network/packet/in/PacketInCreateTemplate.java
@@ -199,6 +199,11 @@ public final class PacketInCreateTemplate extends PacketInHandler {
 
     private void extractEntry(ZipFile zipFile, ZipEntry entry, String destDir) throws IOException {
         File file = new File(destDir, entry.getName());
+
+        if (!file.toPath().normalize().startsWith(Paths.get(destDir))) {
+            return;
+        }
+
         final byte[] BUFFER = new byte[0xFFFF];
 
         if (entry.isDirectory()) {

--- a/cloudnet-wrapper/src/main/java/de/dytanic/cloudnetwrapper/server/CloudGameServer.java
+++ b/cloudnet-wrapper/src/main/java/de/dytanic/cloudnetwrapper/server/CloudGameServer.java
@@ -513,6 +513,11 @@ public class CloudGameServer extends AbstractScreenService implements ServerDisp
 
     private void extractEntry(ZipFile zipFile, ZipEntry entry, String destDir) throws IOException {
         File file = new File(destDir, entry.getName());
+
+        if (!file.toPath().normalize().startsWith(Paths.get(destDir))) {
+            return;
+        }
+
         final byte[] BUFFER = new byte[0xFFFF];
 
         if (entry.isDirectory()) {


### PR DESCRIPTION
This adds a check before extracting a zip entry if the output file is in the target directory.
https://lgtm.com/rules/1506728586782/