### PR TITLE
Remove fast connect

### DIFF
--- a/cloudnet-api/cloudnet-api-bridge/src/main/java/de/dytanic/cloudnet/bridge/internal/listener/proxied/ProxiedListener.java
+++ b/cloudnet-api/cloudnet-api-bridge/src/main/java/de/dytanic/cloudnet/bridge/internal/listener/proxied/ProxiedListener.java
@@ -306,46 +306,6 @@ public class ProxiedListener implements Listener {
 
         CloudProxy.getInstance().update();
         CloudAPI.getInstance().getNetworkConnection().sendPacket(new PacketOutLoginSuccess(e.getPlayer().getUniqueId()));
-
-        if (CloudProxy.getInstance().getProxyGroup().getProxyConfig().isFastConnect()) {
-            try {
-
-                Field channelWrapper;
-                try {
-                    channelWrapper = UserConnection.class.getDeclaredField("ch");
-                    channelWrapper.setAccessible(true);
-                } catch (Exception ex) {
-                    channelWrapper = UserConnection.class.getField("ch");
-                    channelWrapper.setAccessible(true);
-                }
-
-                Field field;
-                try {
-                    field = ChannelWrapper.class.getDeclaredField("ch");
-                    field.setAccessible(true);
-                } catch (Exception ex) {
-                    field = ChannelWrapper.class.getField("ch");
-                    field.setAccessible(true);
-                }
-
-                Channel channel = (Channel) field.get(channelWrapper.get(e.getPlayer()));
-                channel.pipeline().addAfter("packet-encoder", "cloudConnection", new MessageToMessageEncoder<DefinedPacket>() {
-                    @Override
-                    protected void encode(ChannelHandlerContext channelHandlerContext, DefinedPacket definedPacket, List<Object> out) throws
-                        Exception {
-                        if (definedPacket instanceof Respawn) {
-                            if (((Respawn) definedPacket).getDimension() != ((UserConnection) e.getPlayer()).getDimension()) {
-                                ((Respawn) definedPacket).setDimension(((UserConnection) e.getPlayer()).getDimension());
-                            }
-                        }
-                        out.add(definedPacket);
-                    }
-                });
-            } catch (IllegalAccessException | NoSuchFieldException e1) {
-                e1.printStackTrace();
-            }
-        }
-
     }
 
     @EventHandler

--- a/cloudnet-core/src/main/java/de/dytanic/cloudnetcore/util/defaults/BasicProxyConfig.java
+++ b/cloudnet-core/src/main/java/de/dytanic/cloudnetcore/util/defaults/BasicProxyConfig.java
@@ -21,7 +21,6 @@ public class BasicProxyConfig extends ProxyConfig {
                        "         §bMaintenance §8» §7We are still in §bmaintenance"),
               "§8➜ §bMaintenance §8§l【§c✘§8§l】",
               1000,
-              false,
               true,
               new AutoSlot(0, false),
               new TabList(true,

--- a/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/proxylayout/ProxyConfig.java
+++ b/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/proxylayout/ProxyConfig.java
@@ -21,8 +21,6 @@ public class ProxyConfig {
 
     private int maxPlayers;
 
-    private boolean fastConnect;
-
     private Boolean customPayloadFixer;
 
     private AutoSlot autoSlot;
@@ -41,7 +39,6 @@ public class ProxyConfig {
                        Motd maintenanceMotdLayout,
                        String maintenaceProtocol,
                        int maxPlayers,
-                       boolean fastConnect,
                        Boolean customPayloadFixer,
                        AutoSlot autoSlot,
                        TabList tabList,
@@ -54,7 +51,6 @@ public class ProxyConfig {
         this.maintenanceMotdLayout = maintenanceMotdLayout;
         this.maintenaceProtocol = maintenaceProtocol;
         this.maxPlayers = maxPlayers;
-        this.fastConnect = fastConnect;
         this.customPayloadFixer = customPayloadFixer;
         this.autoSlot = autoSlot;
         this.tabList = tabList;
@@ -159,15 +155,4 @@ public class ProxyConfig {
         this.enabled = enabled;
     }
 
-    /**
-     * @deprecated this option is not used anymore and will be removed in a future release
-     */
-    @Deprecated
-    public boolean isFastConnect() {
-        return fastConnect;
-    }
-
-    public void setFastConnect(boolean fastConnect) {
-        this.fastConnect = fastConnect;
-    }
 }

--- a/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/proxylayout/ProxyConfig.java
+++ b/cloudnet-lib/src/main/java/de/dytanic/cloudnet/lib/proxylayout/ProxyConfig.java
@@ -159,6 +159,10 @@ public class ProxyConfig {
         this.enabled = enabled;
     }
 
+    /**
+     * @deprecated this option is not used anymore and will be removed in a future release
+     */
+    @Deprecated
     public boolean isFastConnect() {
         return fastConnect;
     }


### PR DESCRIPTION
CloudNet currently has an option called "fast-connect", which doesn't really work.
There are often chunk-bugs, players are invisible etc.
CloudNet does this in way which should be avoided, according to wiki.vg: https://imgur.com/vbOUWhT
In addition, fast connect is not a feature which is necessary in a server-management system.