### PR TITLE
Update haste/paste servers

### DIFF
--- a/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/CloudConfig.java
+++ b/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/CloudConfig.java
@@ -104,8 +104,7 @@ public class CloudConfig {
 
         configuration.set("general.haste.server", Arrays.asList("https://hastebin.com",
                                                                 "https://hasteb.in",
-                                                                "https://haste.llamacloud.io",
-                                                                "https://pastes.cf"));
+                                                                "https://just-paste.it"));
 
         configuration.set("server.hostaddress", hostName);
         configuration.set("server.ports", Collections.singletonList(1410));
@@ -180,8 +179,7 @@ public class CloudConfig {
             if (!configuration.getSection("general").contains("haste")) {
                 configuration.set("general.haste.server", Arrays.asList("https://hastebin.com",
                                                                         "https://hasteb.in",
-                                                                        "https://haste.llamacloud.io",
-                                                                        "https://pastes.cf"));
+                                                                        "https://just-paste.it"));
 
                 try (Writer writer = Files.newBufferedWriter(configPath, StandardCharsets.UTF_8)) {
                     CONFIGURATION_PROVIDER.save(configuration, writer);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU HAVE READ CLOUDNET'S CODESTYLE GUIDELINES -->
<!-- IF YOU'RE NOT FOLLOWING CLOUDNET'S CODESTYLE GUIDELINES, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->
<!-- IF YOU'RE NOT PROVIDING ANY INFORMATION, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->

This pull request includes:

- [ ] breaking changes
- [x] no breaking changes

### Changes made to the repository:

This change fixes non-existing and soon-to-be non-existing haste servers and inserts just-paste.it, a paste server used on the CloudNet Discord.

### Documentation of test results:

All haste servers are now usable:
- "https://hastebin.com"
- "https://hasteb.in"
- "https://just-paste.it"

### Related issues/discussions:

None, this is a preemptive measure.
