### PR TITLE
IPv6 support

### DIFF
--- a/cloudnet-api/cloudnet-api-bridge/src/main/java/eu/cloudnetservice/cloudnet/v2/bridge/BukkitBootstrap.java
+++ b/cloudnet-api/cloudnet-api-bridge/src/main/java/eu/cloudnetservice/cloudnet/v2/bridge/BukkitBootstrap.java
@@ -14,6 +14,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.file.Paths;
+import java.util.logging.Level;
 
 public final class BukkitBootstrap extends JavaPlugin {
 
@@ -29,8 +30,8 @@ public final class BukkitBootstrap extends JavaPlugin {
             api = new CloudAPI(new CloudConfigLoader(Paths.get("CLOUD", "connection.json"),
                                                      Paths.get("CLOUD", "config.json"),
                                                      ConfigTypeLoader.INTERNAL), getLogger());
-        } catch (UnknownHostException e) {
-            e.printStackTrace();
+        } catch (UnknownHostException exception) {
+            this.getLogger().log(Level.SEVERE, "Exception instantiating CloudAPI, this is a bug!", exception);
         }
     }
 
@@ -114,8 +115,8 @@ public final class BukkitBootstrap extends JavaPlugin {
                         this.cloudServer.update();
                     }
                 }
-            } catch (Exception ex) {
-                ex.printStackTrace();
+            } catch (Exception exception) {
+                this.getLogger().log(Level.SEVERE, "Error updating server! This is a bug!", exception);
             }
         };
     }

--- a/cloudnet-api/cloudnet-api-bridge/src/main/java/eu/cloudnetservice/cloudnet/v2/bridge/BukkitBootstrap.java
+++ b/cloudnet-api/cloudnet-api-bridge/src/main/java/eu/cloudnetservice/cloudnet/v2/bridge/BukkitBootstrap.java
@@ -12,11 +12,9 @@ import org.bukkit.event.server.ServerListPingEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.nio.file.Paths;
 
-/**
- * Created by Tareko on 17.08.2017.
- */
 public final class BukkitBootstrap extends JavaPlugin {
 
     /**
@@ -27,9 +25,13 @@ public final class BukkitBootstrap extends JavaPlugin {
 
     @Override
     public void onLoad() {
-        api = new CloudAPI(new CloudConfigLoader(Paths.get("CLOUD", "connection.json"),
-                                                 Paths.get("CLOUD", "config.json"),
-                                                 ConfigTypeLoader.INTERNAL), getLogger());
+        try {
+            api = new CloudAPI(new CloudConfigLoader(Paths.get("CLOUD", "connection.json"),
+                                                     Paths.get("CLOUD", "config.json"),
+                                                     ConfigTypeLoader.INTERNAL), getLogger());
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+        }
     }
 
     @Override
@@ -64,16 +66,6 @@ public final class BukkitBootstrap extends JavaPlugin {
     }
 
     /**
-     * If players are joined on the Bukkit server prior to this plugin being enabled (ie. a reload just happened),
-     * loads all players from the cloud into the cache.
-     */
-    private void loadPlayers() {
-        for (Player all : getServer().getOnlinePlayers()) {
-            api.getOnlinePlayer(all.getUniqueId());
-        }
-    }
-
-    /**
      * Starts the update task for this server.
      */
     private void startUpdateTask() {
@@ -86,6 +78,16 @@ public final class BukkitBootstrap extends JavaPlugin {
             getServer().getScheduler().runTaskTimerAsynchronously(this, updateServer(serverListPingEvent), 0, 5);
         } else {
             getServer().getScheduler().runTaskTimer(this, updateServer(serverListPingEvent), 0, 5);
+        }
+    }
+
+    /**
+     * If players are joined on the Bukkit server prior to this plugin being enabled (ie. a reload just happened),
+     * loads all players from the cloud into the cache.
+     */
+    private void loadPlayers() {
+        for (Player all : getServer().getOnlinePlayers()) {
+            api.getOnlinePlayer(all.getUniqueId());
         }
     }
 

--- a/cloudnet-api/cloudnet-api-bridge/src/main/java/eu/cloudnetservice/cloudnet/v2/bridge/CloudProxy.java
+++ b/cloudnet-api/cloudnet-api-bridge/src/main/java/eu/cloudnetservice/cloudnet/v2/bridge/CloudProxy.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 /**
@@ -312,8 +313,8 @@ public class CloudProxy implements CloudService, NetworkHandler {
                               proxyProcessMeta.getMemory())
                     .fetch(this.cloudAPI::update);
             }
-        } catch (UnknownHostException e) {
-            e.printStackTrace();
+        } catch (UnknownHostException exception) {
+            this.cloudAPI.getLogger().log(Level.SEVERE, "Could not resolve hostname!", exception);
         }
     }
 

--- a/cloudnet-api/cloudnet-api-bridge/src/main/java/eu/cloudnetservice/cloudnet/v2/bridge/CloudProxy.java
+++ b/cloudnet-api/cloudnet-api-bridge/src/main/java/eu/cloudnetservice/cloudnet/v2/bridge/CloudProxy.java
@@ -21,8 +21,11 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Plugin;
+import org.apache.commons.validator.routines.InetAddressValidator;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -228,11 +231,13 @@ public class CloudProxy implements CloudService, NetworkHandler {
         }
     }
 
-    @Override
-    public CompletableFuture<ProxyProcessMeta> waitForProxy(final UUID uuid) {
-        final CompletableFuture<ProxyProcessMeta> future = new CompletableFuture<>();
-        this.waitingProxies.put(uuid, future);
-        return future;
+    /**
+     * Returns the instance of this {@link CloudProxy}.
+     *
+     * @return the singleton instance of this class.
+     */
+    public static CloudProxy getInstance() {
+        return instance;
     }
 
     /**
@@ -294,14 +299,22 @@ public class CloudProxy implements CloudService, NetworkHandler {
      * Updates this proxy instance with all of its' state using the API.
      */
     public void update() {
-        new ProxyInfo(this.cloudAPI.getServiceId(),
-                      this.cloudAPI.getConfig().getString("host"),
-                      0,
-                      true,
-                      ProxyServer.getInstance().getPlayers().stream()
-                                 .collect(Collectors.toMap(ProxiedPlayer::getUniqueId, CommandSender::getName)),
-                      proxyProcessMeta.getMemory())
-            .fetch(this.cloudAPI::update);
+        String host = this.cloudAPI.getConfig().getString("host");
+
+        try {
+            if (InetAddressValidator.getInstance().isValid(host)) {
+                new ProxyInfo(this.cloudAPI.getServiceId(),
+                              InetAddress.getByName(host),
+                              0,
+                              true,
+                              ProxyServer.getInstance().getPlayers().stream()
+                                         .collect(Collectors.toMap(ProxiedPlayer::getUniqueId, CommandSender::getName)),
+                              proxyProcessMeta.getMemory())
+                    .fetch(this.cloudAPI::update);
+            }
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+        }
     }
 
     /**
@@ -353,6 +366,13 @@ public class CloudProxy implements CloudService, NetworkHandler {
     @Override
     public Map<String, ServerInfo> getServers() {
         return this.cachedServers;
+    }
+
+    @Override
+    public CompletableFuture<ProxyProcessMeta> waitForProxy(final UUID uuid) {
+        final CompletableFuture<ProxyProcessMeta> future = new CompletableFuture<>();
+        this.waitingProxies.put(uuid, future);
+        return future;
     }
 
     @Override
@@ -490,15 +510,6 @@ public class CloudProxy implements CloudService, NetworkHandler {
             }
         }
 
-    }
-
-    /**
-     * Returns the instance of this {@link CloudProxy}.
-     *
-     * @return the singleton instance of this class.
-     */
-    public static CloudProxy getInstance() {
-        return instance;
     }
 
     @Override

--- a/cloudnet-api/cloudnet-api-bridge/src/main/java/eu/cloudnetservice/cloudnet/v2/bridge/CloudServer.java
+++ b/cloudnet-api/cloudnet-api-bridge/src/main/java/eu/cloudnetservice/cloudnet/v2/bridge/CloudServer.java
@@ -28,6 +28,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.net.InetAddress;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.file.Files;
@@ -50,7 +51,7 @@ public class CloudServer implements CloudService, NetworkHandler {
     private final BukkitBootstrap bukkitBootstrap;
 
     private final Map<UUID, CloudPlayer> cloudPlayers = new ConcurrentHashMap<>();
-    private final String hostAddress;
+    private final InetAddress hostAddress;
     private final int port;
     private final Template template;
     private final int memory;
@@ -210,7 +211,7 @@ public class CloudServer implements CloudService, NetworkHandler {
         return port;
     }
 
-    public String getHostAddress() {
+    public InetAddress getHostAddress() {
         return hostAddress;
     }
 

--- a/cloudnet-api/cloudnet-api-bridge/src/main/java/eu/cloudnetservice/cloudnet/v2/bridge/ProxiedBootstrap.java
+++ b/cloudnet-api/cloudnet-api-bridge/src/main/java/eu/cloudnetservice/cloudnet/v2/bridge/ProxiedBootstrap.java
@@ -11,6 +11,7 @@ import eu.cloudnetservice.cloudnet.v2.bridge.internal.listener.proxied.ProxiedLi
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.plugin.Plugin;
 
+import java.net.UnknownHostException;
 import java.nio.file.Paths;
 import java.util.logging.Level;
 
@@ -32,9 +33,13 @@ public class ProxiedBootstrap extends Plugin {
 
     @Override
     public void onLoad() {
-        this.api = new CloudAPI(new CloudConfigLoader(Paths.get("CLOUD", "connection.json"),
-                                                      Paths.get("CLOUD", "config.json"),
-                                                      ConfigTypeLoader.INTERNAL), this.getLogger());
+        try {
+            this.api = new CloudAPI(new CloudConfigLoader(Paths.get("CLOUD", "connection.json"),
+                                                          Paths.get("CLOUD", "config.json"),
+                                                          ConfigTypeLoader.INTERNAL), this.getLogger());
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+        }
         getLogger().setLevel(Level.INFO);
     }
 

--- a/cloudnet-api/cloudnet-api-bridge/src/main/java/eu/cloudnetservice/cloudnet/v2/bridge/ProxiedBootstrap.java
+++ b/cloudnet-api/cloudnet-api-bridge/src/main/java/eu/cloudnetservice/cloudnet/v2/bridge/ProxiedBootstrap.java
@@ -37,8 +37,8 @@ public class ProxiedBootstrap extends Plugin {
             this.api = new CloudAPI(new CloudConfigLoader(Paths.get("CLOUD", "connection.json"),
                                                           Paths.get("CLOUD", "config.json"),
                                                           ConfigTypeLoader.INTERNAL), this.getLogger());
-        } catch (UnknownHostException e) {
-            e.printStackTrace();
+        } catch (UnknownHostException exception) {
+            this.getLogger().log(Level.SEVERE, "Exception instantiating CloudAPI, this is a bug!", exception);
         }
         getLogger().setLevel(Level.INFO);
     }

--- a/cloudnet-api/cloudnet-api-core/src/main/java/eu/cloudnetservice/cloudnet/v2/api/CloudAPI.java
+++ b/cloudnet-api/cloudnet-api-core/src/main/java/eu/cloudnetservice/cloudnet/v2/api/CloudAPI.java
@@ -72,7 +72,7 @@ public final class CloudAPI {
         this.cloudConfigLoader = loader;
         this.logger = logger;
         this.config = loader.loadConfig();
-        this.networkConnection = new NetworkConnection(loader.loadConnnection(),
+        this.networkConnection = new NetworkConnection(loader.loadConnection(),
                                                        new ConnectableAddress(InetAddress.getByName("0.0.0.0"), 0));
         this.serviceId = config.getObject("serviceId", ServiceId.TYPE);
         this.memory = config.getInt("memory");
@@ -534,7 +534,7 @@ public final class CloudAPI {
                          String.format("Creating server log url: %s%n", serverId));
         String rnd = NetworkUtils.randomString(10);
         networkConnection.sendPacket(new PacketOutCreateServerLog(rnd, serverId));
-        ConnectableAddress connectableAddress = cloudConfigLoader.loadConnnection();
+        ConnectableAddress connectableAddress = cloudConfigLoader.loadConnection();
         return String.format("http://%s:%d/cloudnet/log?server=%s", connectableAddress.getHostName(), cloudNetwork.getWebPort(), rnd);
     }
 

--- a/cloudnet-api/cloudnet-api-core/src/main/java/eu/cloudnetservice/cloudnet/v2/api/CloudAPI.java
+++ b/cloudnet-api/cloudnet-api-core/src/main/java/eu/cloudnetservice/cloudnet/v2/api/CloudAPI.java
@@ -32,6 +32,8 @@ import net.md_5.bungee.api.ProxyServer;
 import org.bukkit.Bukkit;
 
 import java.lang.reflect.Type;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -62,7 +64,7 @@ public final class CloudAPI {
     //Init
     private CloudNetwork cloudNetwork = new CloudNetwork();
 
-    public CloudAPI(CloudConfigLoader loader, final Logger logger) {
+    public CloudAPI(CloudConfigLoader loader, final Logger logger) throws UnknownHostException {
         if (instance != null) {
             throw new IllegalStateException("CloudAPI already instantiated.");
         }
@@ -70,7 +72,8 @@ public final class CloudAPI {
         this.cloudConfigLoader = loader;
         this.logger = logger;
         this.config = loader.loadConfig();
-        this.networkConnection = new NetworkConnection(loader.loadConnnection(), new ConnectableAddress("0.0.0.0", 0));
+        this.networkConnection = new NetworkConnection(loader.loadConnnection(),
+                                                       new ConnectableAddress(InetAddress.getByName("0.0.0.0"), 0));
         this.serviceId = config.getObject("serviceId", ServiceId.TYPE);
         this.memory = config.getInt("memory");
 

--- a/cloudnet-api/cloudnet-api-core/src/main/java/eu/cloudnetservice/cloudnet/v2/api/config/CloudConfigLoader.java
+++ b/cloudnet-api/cloudnet-api-core/src/main/java/eu/cloudnetservice/cloudnet/v2/api/config/CloudConfigLoader.java
@@ -35,7 +35,7 @@ public class CloudConfigLoader {
         return Document.loadDocument(pathConfigJson);
     }
 
-    public ConnectableAddress loadConnnection() {
+    public ConnectableAddress loadConnection() {
         return Document.loadDocument(pathConnectionJson).getObject("connection", ConnectableAddress.TYPE);
     }
 

--- a/cloudnet-api/pom.xml
+++ b/cloudnet-api/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.6</version>
+            <version>${dependency.commons-validator.version}</version>
         </dependency>
     </dependencies>
 

--- a/cloudnet-api/pom.xml
+++ b/cloudnet-api/pom.xml
@@ -63,6 +63,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/commons-validator/commons-validator -->
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.6</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/cloudnet-lib/src/main/java/eu/cloudnetservice/cloudnet/v2/lib/ConnectableAddress.java
+++ b/cloudnet-lib/src/main/java/eu/cloudnetservice/cloudnet/v2/lib/ConnectableAddress.java
@@ -5,18 +5,14 @@ import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
 import java.net.InetAddress;
 
-/**
- * Class specifying a Adress & Port Combination
- * for Wrapper & Master Connections
- */
 public class ConnectableAddress {
 
     public static final Type TYPE = TypeToken.get(ConnectableAddress.class).getType();
     private final InetAddress hostName;
     private final int port;
 
-    public ConnectableAddress(InetAddress adress, int port) {
-        this.hostName = adress;
+    public ConnectableAddress(InetAddress address, int port) {
+        this.hostName = address;
         this.port = port;
     }
 

--- a/cloudnet-lib/src/main/java/eu/cloudnetservice/cloudnet/v2/lib/ConnectableAddress.java
+++ b/cloudnet-lib/src/main/java/eu/cloudnetservice/cloudnet/v2/lib/ConnectableAddress.java
@@ -3,18 +3,20 @@ package eu.cloudnetservice.cloudnet.v2.lib;
 import com.google.gson.reflect.TypeToken;
 
 import java.lang.reflect.Type;
+import java.net.InetAddress;
 
 /**
- * Created by Tareko on 07.06.2017.
+ * Class specifying a Adress & Port Combination
+ * for Wrapper & Master Connections
  */
 public class ConnectableAddress {
 
     public static final Type TYPE = TypeToken.get(ConnectableAddress.class).getType();
-    private final String hostName;
+    private final InetAddress hostName;
     private final int port;
 
-    public ConnectableAddress(String hostName, int port) {
-        this.hostName = hostName;
+    public ConnectableAddress(InetAddress adress, int port) {
+        this.hostName = adress;
         this.port = port;
     }
 
@@ -22,7 +24,7 @@ public class ConnectableAddress {
         return port;
     }
 
-    public String getHostName() {
+    public InetAddress getHostName() {
         return hostName;
     }
 }

--- a/cloudnet-lib/src/main/java/eu/cloudnetservice/cloudnet/v2/lib/network/NetworkConnection.java
+++ b/cloudnet-lib/src/main/java/eu/cloudnetservice/cloudnet/v2/lib/network/NetworkConnection.java
@@ -152,9 +152,9 @@ public final class NetworkConnection implements PacketSender {
                                                  .channel(NetworkUtils.socketChannel());
             InetAddress addr = connectableAddress.getHostName();
             InetSocketAddress dest = new InetSocketAddress(addr, connectableAddress.getPort());
-            InetSocketAddress localdest = new InetSocketAddress(localAddress.getHostName(), localAddress.getPort());
+            InetSocketAddress localAddress = new InetSocketAddress(this.localAddress.getHostName(), this.localAddress.getPort());
 
-            this.channel = bootstrap.connect(dest, localdest)
+            this.channel = bootstrap.connect(dest, localAddress)
                                     .sync()
                                     .channel()
                                     .writeAndFlush(new PacketOutAuth(auth))
@@ -182,7 +182,9 @@ public final class NetworkConnection implements PacketSender {
 
     public boolean isConnected() {
         return channel != null;
-    }    @Override
+    }
+
+    @Override
     public void send(Object object) {
         if (channel == null) {
             return;
@@ -194,8 +196,6 @@ public final class NetworkConnection implements PacketSender {
             channel.eventLoop().execute(() -> channel.writeAndFlush(object));
         }
     }
-
-
 
 
     @Override

--- a/cloudnet-lib/src/main/java/eu/cloudnetservice/cloudnet/v2/lib/network/NetworkConnection.java
+++ b/cloudnet-lib/src/main/java/eu/cloudnetservice/cloudnet/v2/lib/network/NetworkConnection.java
@@ -12,6 +12,9 @@ import eu.cloudnetservice.cloudnet.v2.lib.network.protocol.packet.PacketSender;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.*;
 
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;

--- a/cloudnet-lib/src/main/java/eu/cloudnetservice/cloudnet/v2/lib/process/ProxyProcessData.java
+++ b/cloudnet-lib/src/main/java/eu/cloudnetservice/cloudnet/v2/lib/process/ProxyProcessData.java
@@ -78,7 +78,8 @@ public class ProxyProcessData {
                             final List<String> proxyProcessParameters,
                             final String templateUrl,
                             final Set<ServerInstallablePlugin> plugins,
-                            final Document properties) {
+                            final Document properties,
+                            final ServiceId serviceId) {
         this.wrapperName = wrapperName;
         this.proxyGroupName = proxyGroupName;
         this.memory = memory;
@@ -87,9 +88,10 @@ public class ProxyProcessData {
         this.templateUrl = templateUrl;
         this.plugins = plugins;
         this.properties = properties;
+        this.serviceId = serviceId;
     }
 
-    public ProxyProcessData(final ProxyProcessData proxyProcessData) {
+    public ProxyProcessData(final ProxyProcessData proxyProcessData, final ServiceId serviceId) {
         this.wrapperName = proxyProcessData.wrapperName;
         this.proxyGroupName = proxyProcessData.proxyGroupName;
         this.memory = proxyProcessData.memory;
@@ -98,6 +100,7 @@ public class ProxyProcessData {
         this.templateUrl = proxyProcessData.templateUrl;
         this.plugins = proxyProcessData.plugins;
         this.properties = proxyProcessData.properties;
+        this.serviceId = serviceId;
     }
 
     @Override
@@ -110,6 +113,7 @@ public class ProxyProcessData {
         result = 31 * result + (templateUrl != null ? templateUrl.hashCode() : 0);
         result = 31 * result + (plugins != null ? plugins.hashCode() : 0);
         result = 31 * result + (properties != null ? properties.hashCode() : 0);
+        result = 31 * result + (serviceId != null ? serviceId.hashCode() : 0);
         return result;
     }
 
@@ -145,20 +149,24 @@ public class ProxyProcessData {
         if (!Objects.equals(plugins, that.plugins)) {
             return false;
         }
-        return Objects.equals(properties, that.properties);
+        if (!Objects.equals(properties, that.properties)) {
+            return false;
+        }
+        return Objects.equals(serviceId, that.serviceId);
     }
 
     @Override
     public String toString() {
         return "ProxyProcessData{" +
-            "wrapper='" + wrapperName + '\'' +
-            ", proxyGroup=" + proxyGroupName +
+            "wrapperName='" + wrapperName + '\'' +
+            ", proxyGroupName='" + proxyGroupName + '\'' +
             ", memory=" + memory +
             ", javaProcessParameters=" + javaProcessParameters +
             ", proxyProcessParameters=" + proxyProcessParameters +
             ", templateUrl='" + templateUrl + '\'' +
             ", plugins=" + plugins +
             ", properties=" + properties +
+            ", serviceId=" + serviceId +
             '}';
     }
 

--- a/cloudnet-lib/src/main/java/eu/cloudnetservice/cloudnet/v2/lib/server/ProxyProcessMeta.java
+++ b/cloudnet-lib/src/main/java/eu/cloudnetservice/cloudnet/v2/lib/server/ProxyProcessMeta.java
@@ -8,7 +8,6 @@ import eu.cloudnetservice.cloudnet.v2.lib.utility.document.Document;
 
 import java.lang.reflect.Type;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -17,8 +16,6 @@ import java.util.Set;
 public class ProxyProcessMeta extends ProxyProcessData {
 
     public static final Type TYPE = TypeToken.get(ProxyProcessMeta.class).getType();
-
-    private final ServiceId serviceId;
     private final int port;
 
     public ProxyProcessMeta(final String wrapperName,
@@ -31,23 +28,28 @@ public class ProxyProcessMeta extends ProxyProcessData {
                             final Document properties,
                             final ServiceId serviceId,
                             final int port) {
-        super(wrapperName, proxyGroupName, memory, javaProcessParameters, proxyProcessParameters, templateUrl, plugins, properties);
-        this.serviceId = serviceId;
+        super(wrapperName,
+              proxyGroupName,
+              memory,
+              javaProcessParameters,
+              proxyProcessParameters,
+              templateUrl,
+              plugins,
+              properties,
+              serviceId);
         this.port = port;
     }
 
     public ProxyProcessMeta(final ProxyProcessData proxyProcessData,
                             final ServiceId serviceId,
                             final int port) {
-        super(proxyProcessData);
-        this.serviceId = serviceId;
+        super(proxyProcessData, serviceId);
         this.port = port;
     }
 
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (serviceId != null ? serviceId.hashCode() : 0);
         result = 31 * result + port;
         return result;
     }
@@ -66,22 +68,14 @@ public class ProxyProcessMeta extends ProxyProcessData {
 
         final ProxyProcessMeta that = (ProxyProcessMeta) o;
 
-        if (port != that.port) {
-            return false;
-        }
-        return Objects.equals(serviceId, that.serviceId);
+        return port == that.port;
     }
 
     @Override
     public String toString() {
         return "ProxyProcessMeta{" +
-            "serviceId=" + serviceId +
-            ", port=" + port +
+            "port=" + port +
             "} " + super.toString();
-    }
-
-    public ServiceId getServiceId() {
-        return serviceId;
     }
 
     public int getPort() {

--- a/cloudnet-lib/src/main/java/eu/cloudnetservice/cloudnet/v2/lib/server/info/ProxyInfo.java
+++ b/cloudnet-lib/src/main/java/eu/cloudnetservice/cloudnet/v2/lib/server/info/ProxyInfo.java
@@ -4,6 +4,7 @@ import com.google.gson.reflect.TypeToken;
 import eu.cloudnetservice.cloudnet.v2.lib.service.ServiceId;
 
 import java.lang.reflect.Type;
+import java.net.InetAddress;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -14,14 +15,14 @@ public class ProxyInfo {
 
     private final ServiceId serviceId;
 
-    private final String host;
+    private final InetAddress host;
     private final boolean online;
     private final Map<UUID, String> players;
     private final int memory;
     private final int port;
 
     public ProxyInfo(ServiceId serviceId,
-                     String host,
+                     InetAddress host,
                      int port,
                      boolean online,
                      Map<UUID, String> players,
@@ -66,7 +67,7 @@ public class ProxyInfo {
         return online;
     }
 
-    public String getHost() {
+    public InetAddress getHost() {
         return host;
     }
 

--- a/cloudnet-lib/src/main/java/eu/cloudnetservice/cloudnet/v2/lib/server/info/ServerInfo.java
+++ b/cloudnet-lib/src/main/java/eu/cloudnetservice/cloudnet/v2/lib/server/info/ServerInfo.java
@@ -7,6 +7,7 @@ import eu.cloudnetservice.cloudnet.v2.lib.server.template.Template;
 import eu.cloudnetservice.cloudnet.v2.lib.service.ServiceId;
 
 import java.lang.reflect.Type;
+import java.net.InetAddress;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -15,7 +16,7 @@ public class ServerInfo {
     public static final Type TYPE = TypeToken.get(ServerInfo.class).getType();
 
     private final ServiceId serviceId;
-    private final String host;
+    private final InetAddress host;
     private final boolean online;
     private final List<String> players;
     private final int port;
@@ -27,7 +28,7 @@ public class ServerInfo {
     private ServerState serverState;
 
     public ServerInfo(ServiceId serviceId,
-                      String host,
+                      InetAddress host,
                       int port,
                       boolean online,
                       List<String> players,
@@ -180,7 +181,7 @@ public class ServerInfo {
         return serviceId;
     }
 
-    public String getHost() {
+    public InetAddress getHost() {
         return host;
     }
 

--- a/cloudnet-lib/src/main/java/eu/cloudnetservice/cloudnet/v2/lib/server/info/SimpleProxyInfo.java
+++ b/cloudnet-lib/src/main/java/eu/cloudnetservice/cloudnet/v2/lib/server/info/SimpleProxyInfo.java
@@ -2,6 +2,8 @@ package eu.cloudnetservice.cloudnet.v2.lib.server.info;
 
 import eu.cloudnetservice.cloudnet.v2.lib.service.ServiceId;
 
+import java.net.InetAddress;
+
 /**
  * Created by Tareko on 02.07.2017.
  */
@@ -9,12 +11,12 @@ public class SimpleProxyInfo {
 
     private final ServiceId serviceId;
     private final boolean online;
-    private final String hostName;
+    private final InetAddress hostName;
     private final int port;
     private final int memory;
     private final int onlineCount;
 
-    public SimpleProxyInfo(ServiceId serviceId, boolean online, String hostName, int port, int memory, int onlineCount) {
+    public SimpleProxyInfo(ServiceId serviceId, boolean online, InetAddress hostName, int port, int memory, int onlineCount) {
         this.serviceId = serviceId;
         this.online = online;
         this.hostName = hostName;
@@ -39,7 +41,7 @@ public class SimpleProxyInfo {
         return memory;
     }
 
-    public String getHostName() {
+    public InetAddress getHostName() {
         return hostName;
     }
 

--- a/cloudnet-lib/src/main/java/eu/cloudnetservice/cloudnet/v2/lib/server/info/SimpleServerInfo.java
+++ b/cloudnet-lib/src/main/java/eu/cloudnetservice/cloudnet/v2/lib/server/info/SimpleServerInfo.java
@@ -2,11 +2,13 @@ package eu.cloudnetservice.cloudnet.v2.lib.server.info;
 
 import eu.cloudnetservice.cloudnet.v2.lib.service.ServiceId;
 
+import java.net.InetAddress;
+
 public class SimpleServerInfo {
 
     private final ServiceId serviceId;
 
-    private final String hostAddress;
+    private final InetAddress hostAddress;
 
     private final int port;
 
@@ -14,7 +16,7 @@ public class SimpleServerInfo {
 
     private final int maxPlayers;
 
-    public SimpleServerInfo(ServiceId serviceId, String hostAddress, int port, int onlineCount, int maxPlayers) {
+    public SimpleServerInfo(ServiceId serviceId, InetAddress hostAddress, int port, int onlineCount, int maxPlayers) {
         this.serviceId = serviceId;
         this.hostAddress = hostAddress;
         this.port = port;
@@ -38,7 +40,7 @@ public class SimpleServerInfo {
         return maxPlayers;
     }
 
-    public String getHostAddress() {
+    public InetAddress getHostAddress() {
         return hostAddress;
     }
 }

--- a/cloudnet-master/pom.xml
+++ b/cloudnet-master/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.6</version>
+            <version>${dependency.commons-validator.version}</version>
         </dependency>
     </dependencies>
 

--- a/cloudnet-master/pom.xml
+++ b/cloudnet-master/pom.xml
@@ -69,6 +69,12 @@
             <version>${dependency.slf4j.version}</version>
             <scope>compile</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/commons-validator/commons-validator -->
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.6</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/CloudConfig.java
+++ b/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/CloudConfig.java
@@ -131,10 +131,15 @@ public class CloudConfig {
         }
 
         String hostName = NetworkUtils.getHostName();
-        new Document("wrapper", Collections.singletonList(new WrapperMeta("Wrapper-1", hostName, "admin")))
-            .append("proxyGroups", Collections.singletonList(new BungeeGroup())).saveAsConfig(servicePath);
+        try {
+            new Document("wrapper", Collections.singletonList(new WrapperMeta("Wrapper-1", InetAddress.getByName(hostName), "admin")))
+                .append("proxyGroups", Collections.singletonList(new BungeeGroup())).saveAsConfig(servicePath);
 
-        new Document("group", new LobbyGroup()).saveAsConfig(Paths.get("groups/Lobby.json"));
+            new Document("group", new LobbyGroup()).saveAsConfig(Paths.get("groups/Lobby.json"));
+
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+        }
     }
 
     private void defaultInitUsers() {

--- a/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/CloudConfig.java
+++ b/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/CloudConfig.java
@@ -16,9 +16,12 @@ import eu.cloudnetservice.cloudnet.v2.web.server.util.WebServerConfig;
 import net.md_5.bungee.config.Configuration;
 import net.md_5.bungee.config.ConfigurationProvider;
 import net.md_5.bungee.config.YamlConfiguration;
+import org.apache.commons.validator.routines.InetAddressValidator;
 
 import java.io.*;
 import java.lang.reflect.Type;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -76,7 +79,7 @@ public class CloudConfig {
             try {
                 Files.createDirectories(path);
             } catch (IOException e) {
-                 throw new RuntimeException("Folder path " + path.toAbsolutePath().toString() + " could not be created", e);
+                throw new RuntimeException("Folder path " + path.toAbsolutePath().toString() + " could not be created", e);
             }
         }
 
@@ -156,9 +159,16 @@ public class CloudConfig {
 
             String host = configuration.getString("server.hostaddress");
 
+            InetAddressValidator validator = new InetAddressValidator();
+            if (!validator.isValid(host)) {
+                throw new UnknownHostException("No valid InetAdress found!");
+            }
+
+            InetAddress hostInet = InetAddress.getByName(host);
+
             Collection<ConnectableAddress> addresses = new ArrayList<>();
             for (int value : configuration.getIntList("server.ports")) {
-                addresses.add(new ConnectableAddress(host, value));
+                addresses.add(new ConnectableAddress(hostInet, value));
             }
             this.addresses = addresses;
 

--- a/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/CloudConfig.java
+++ b/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/CloudConfig.java
@@ -79,7 +79,7 @@ public class CloudConfig {
             try {
                 Files.createDirectories(path);
             } catch (IOException e) {
-                throw new RuntimeException("Folder path " + path.toAbsolutePath().toString() + " could not be created", e);
+                throw new RuntimeException("Folder path " + path.toAbsolutePath() + " could not be created", e);
             }
         }
 
@@ -165,7 +165,7 @@ public class CloudConfig {
 
             InetAddressValidator validator = new InetAddressValidator();
             if (!validator.isValid(host)) {
-                throw new UnknownHostException("No valid InetAdress found!");
+                throw new UnknownHostException("No valid InetAddress found!");
             }
 
             InetAddress hostInet = InetAddress.getByName(host);

--- a/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/bootstrap/CloudBootstrap.java
+++ b/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/bootstrap/CloudBootstrap.java
@@ -12,6 +12,7 @@ import io.netty.util.internal.logging.JdkLoggerFactory;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
@@ -22,7 +23,7 @@ public final class CloudBootstrap {
 
     private static final InternalLoggerFactory INTERNAL_LOGGER_FACTORY = InternalLoggerFactory.getDefaultFactory();
 
-    public static synchronized void main(String[] args) {
+    public static synchronized void main(String[] args) throws IOException {
         System.setProperty("file.encoding", "UTF-8");
 
         InternalLoggerFactory.setDefaultFactory(JdkLoggerFactory.INSTANCE);

--- a/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/bootstrap/CloudBootstrap.java
+++ b/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/bootstrap/CloudBootstrap.java
@@ -24,8 +24,6 @@ public final class CloudBootstrap {
 
     public static synchronized void main(String[] args) {
         System.setProperty("file.encoding", "UTF-8");
-        System.setProperty("java.net.preferIPv6Stack", "true");
-        System.setProperty("java.net.preferIPv4Stack", "false");
 
         InternalLoggerFactory.setDefaultFactory(JdkLoggerFactory.INSTANCE);
 

--- a/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/bootstrap/CloudBootstrap.java
+++ b/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/bootstrap/CloudBootstrap.java
@@ -24,7 +24,8 @@ public final class CloudBootstrap {
 
     public static synchronized void main(String[] args) {
         System.setProperty("file.encoding", "UTF-8");
-        System.setProperty("java.net.preferIPv4Stack", "true");
+        System.setProperty("java.net.preferIPv6Stack", "true");
+        System.setProperty("java.net.preferIPv4Stack", "false");
 
         InternalLoggerFactory.setDefaultFactory(JdkLoggerFactory.INSTANCE);
 

--- a/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/network/CloudNetServer.java
+++ b/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/network/CloudNetServer.java
@@ -87,7 +87,7 @@ public final class CloudNetServer extends ChannelInitializer<Channel> implements
             InetSocketAddress address = (InetSocketAddress) channel.remoteAddress();
 
             for (Wrapper wrapper : CloudNet.getInstance().getWrappers().values()) {
-                if (wrapper.getNetworkInfo().getHostName().equalsIgnoreCase(address.getAddress().getHostAddress())) {
+                if (wrapper.getNetworkInfo().getHostName().getHostAddress().equals(address.getAddress().getHostAddress())) {
 
                     NetworkUtils.initChannel(channel);
                     channel.pipeline().addLast("client", new CloudNetClientAuth(channel));

--- a/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/network/NetworkInfo.java
+++ b/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/network/NetworkInfo.java
@@ -1,21 +1,21 @@
 package eu.cloudnetservice.cloudnet.v2.master.network;
 
-/**
- * Created by Tareko on 27.05.2017.
- */
+
+import java.net.InetAddress;
+
 public class NetworkInfo {
 
     private final String serverId;
-    private final String hostName;
+    private final InetAddress hostName;
     private final int port;
 
-    public NetworkInfo(String serverId, String hostName, int port) {
+    public NetworkInfo(String serverId, InetAddress hostName, int port) {
         this.serverId = serverId;
         this.hostName = hostName;
         this.port = port;
     }
 
-    public String getHostName() {
+    public InetAddress getHostName() {
         return hostName;
     }
 

--- a/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/network/components/WrapperMeta.java
+++ b/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/network/components/WrapperMeta.java
@@ -1,19 +1,17 @@
 package eu.cloudnetservice.cloudnet.v2.master.network.components;
 
+import java.net.InetAddress;
 import java.util.Objects;
 
-/**
- * Created by Tareko on 24.07.2017.
- */
 public class WrapperMeta {
 
     private final String id;
 
-    private final String hostName;
+    private final InetAddress hostName;
 
     private final String user;
 
-    public WrapperMeta(String id, String hostName, String user) {
+    public WrapperMeta(String id, InetAddress hostName, String user) {
         this.id = id;
         this.hostName = hostName;
         this.user = user;
@@ -23,7 +21,7 @@ public class WrapperMeta {
         return id;
     }
 
-    public String getHostName() {
+    public InetAddress getHostName() {
         return hostName;
     }
 

--- a/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/setup/SetupWrapper.java
+++ b/cloudnet-master/src/main/java/eu/cloudnetservice/cloudnet/v2/master/setup/SetupWrapper.java
@@ -10,6 +10,7 @@ import org.apache.commons.validator.routines.InetAddressValidator;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.logging.Level;
 
 public class SetupWrapper {
 
@@ -21,7 +22,7 @@ public class SetupWrapper {
 
         setup = new Setup().setupCancel(() -> System.out.println("Setup was cancelled"))
                            .setupComplete(data -> {
-                               try{
+                               try {
                                    InetAddress host = InetAddress.getByName(data.getString("address"));
                                    String user = data.getString("user");
 
@@ -29,8 +30,8 @@ public class SetupWrapper {
                                    CloudNet.getInstance().getConfig().createWrapper(wrapperMeta);
                                    commandSender.sendMessage(String.format("Wrapper [%s] was registered on CloudNet",
                                                                            wrapperMeta.getId()));
-                               }catch (UnknownHostException ex){
-                                   ex.printStackTrace();
+                               } catch (UnknownHostException exception) {
+                                   CloudNet.getLogger().log(Level.SEVERE, "Could not resolve hostname!", exception);
                                }
                            });
 

--- a/cloudnet-wrapper/pom.xml
+++ b/cloudnet-wrapper/pom.xml
@@ -44,6 +44,13 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/commons-validator/commons-validator -->
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.6</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/cloudnet-wrapper/pom.xml
+++ b/cloudnet-wrapper/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.6</version>
+            <version>${dependency.commons-validator.version}</version>
         </dependency>
 
     </dependencies>

--- a/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/CloudNetWrapper.java
+++ b/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/CloudNetWrapper.java
@@ -72,7 +72,7 @@ public final class CloudNetWrapper implements Executable, ShutdownOnCentral {
         this.cloudNetLogging = cloudNetLogging;
 
         if (!cloudNetWrapperConfig.getCloudnetHost().isPresent()) {
-            throw new NullPointerException("No CloudNet host defined!");
+            throw new NullPointerException("no cloudnet host defined!");
         }
 
         InetAddress address = cloudNetWrapperConfig.getCloudnetHost().get();

--- a/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/CloudNetWrapper.java
+++ b/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/CloudNetWrapper.java
@@ -39,6 +39,7 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 
 public final class CloudNetWrapper implements Executable, ShutdownOnCentral {
 
@@ -77,8 +78,8 @@ public final class CloudNetWrapper implements Executable, ShutdownOnCentral {
             new ConnectableAddress(cloudNetWrapperConfig.getInternalIP(), 0), () -> {
             try {
                 onShutdownCentral();
-            } catch (Exception e) {
-                e.printStackTrace();
+            } catch (Exception exception) {
+                this.cloudNetLogging.log(Level.SEVERE, "Central exception when trying to shutdown the network connection!", exception);
             }
         });
 

--- a/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/CloudNetWrapper.java
+++ b/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/CloudNetWrapper.java
@@ -34,7 +34,6 @@ import eu.cloudnetservice.cloudnet.v2.wrapper.util.ShutdownOnCentral;
 import joptsimple.OptionSet;
 
 import java.io.File;
-import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Map;
@@ -71,15 +70,10 @@ public final class CloudNetWrapper implements Executable, ShutdownOnCentral {
         this.wrapperConfig = cloudNetWrapperConfig;
         this.cloudNetLogging = cloudNetLogging;
 
-        if (!cloudNetWrapperConfig.getCloudnetHost().isPresent()) {
-            throw new NullPointerException("no cloudnet host defined!");
-        }
-
-        InetAddress address = cloudNetWrapperConfig.getCloudnetHost().get();
         this.networkConnection = new NetworkConnection(
             new ConnectableAddress(
-                address,
-                cloudNetWrapperConfig.getCloudnetPort()),
+                cloudNetWrapperConfig.getCloudNetHost(),
+                cloudNetWrapperConfig.getCloudNetPort()),
             new ConnectableAddress(cloudNetWrapperConfig.getInternalIP(), 0), () -> {
             try {
                 onShutdownCentral();

--- a/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/CloudNetWrapper.java
+++ b/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/CloudNetWrapper.java
@@ -34,6 +34,7 @@ import eu.cloudnetservice.cloudnet.v2.wrapper.util.ShutdownOnCentral;
 import joptsimple.OptionSet;
 
 import java.io.File;
+import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Map;
@@ -69,18 +70,24 @@ public final class CloudNetWrapper implements Executable, ShutdownOnCentral {
 
         this.wrapperConfig = cloudNetWrapperConfig;
         this.cloudNetLogging = cloudNetLogging;
+
+        if (!cloudNetWrapperConfig.getCloudnetHost().isPresent()) {
+            throw new NullPointerException("No CloudNet host defined!");
+        }
+
+        InetAddress address = cloudNetWrapperConfig.getCloudnetHost().get();
         this.networkConnection = new NetworkConnection(
             new ConnectableAddress(
-                cloudNetWrapperConfig.getCloudnetHost(),
+                address,
                 cloudNetWrapperConfig.getCloudnetPort()),
-            new ConnectableAddress(cloudNetWrapperConfig.getInternalIP(), 0),
-            () -> {
-                try {
-                    onShutdownCentral();
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            });
+            new ConnectableAddress(cloudNetWrapperConfig.getInternalIP(), 0), () -> {
+            try {
+                onShutdownCentral();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+
 
         String key = NetworkUtils.readWrapperKey();
 

--- a/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/CloudNetWrapperConfig.java
+++ b/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/CloudNetWrapperConfig.java
@@ -5,12 +5,16 @@ import jline.console.ConsoleReader;
 import net.md_5.bungee.config.Configuration;
 import net.md_5.bungee.config.ConfigurationProvider;
 import net.md_5.bungee.config.YamlConfiguration;
+import org.apache.commons.validator.routines.InetAddressValidator;
 
 import java.io.*;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
 
 public class CloudNetWrapperConfig {
 
@@ -18,7 +22,10 @@ public class CloudNetWrapperConfig {
 
     private Configuration configuration;
 
-    private String internalIP, wrapperId, cloudnetHost, proxyConfigHost;
+    private Optional<String> cloudnet4Host = Optional.empty();
+    private Optional<String> cloudnet6Host = Optional.empty();
+
+    private String internalIP, wrapperId, proxyConfigHost;
 
     private boolean savingRecords, autoUpdate, maintenanceCopy;
 
@@ -50,19 +57,47 @@ public class CloudNetWrapperConfig {
                 hostName = System.getProperty("hostAddress");
             }
 
+            Optional<String> host4Name = Optional.empty();
+            Optional<String> host6Name = Optional.empty();
+            InetAddressValidator validator = new InetAddressValidator();
+
             if (hostName.equals("127.0.0.1") || hostName.equals("127.0.1.1") || hostName.split("\\.").length != 4) {
                 String input;
-                System.out.println("Your local IP address is 127.0.0.1, please provide your service ip");
+                System.out.println("Please provide your service ipv4, leave blank for only ipv6");
+                System.out.println("Only Ipv6 is not recommended!");
                 while ((input = reader.readLine()) != null) {
-                    if ((input.equals("127.0.0.1") || input.equals("127.0.1.1") || input.split("\\.").length != 4)) {
-                        System.out.println("Please provide your real ip address :)");
+                    if (input.isEmpty()) {
+                        host4Name = Optional.empty();
+                        break;
+                    }
+                    if (!validator.isValidInet4Address(input)) {
+                        System.out.println("Please provide your real ipv4 address :)");
                         continue;
                     }
+                    host4Name = Optional.of(input);
+                    break;
+                }
 
-                    hostName = input;
+                System.out.println("please provide your service ipv6, leave blank for only ipv4");
+                while ((input = reader.readLine()) != null) {
+                    if (input.isEmpty()) {
+                        host6Name = Optional.empty();
+                        break;
+                    }
+                    if (!validator.isValidInet6Address(input)) {
+                        System.out.println("Please provide your real ipv6 address :)");
+                        continue;
+                    }
+                    host6Name = Optional.of(input);
                     break;
                 }
             }
+
+            if (!host4Name.isPresent() && !host6Name.isPresent()) {
+                //TODO: Exit or rerequest data
+                System.exit(0);
+            }
+
 
             String wrapperId = null;
             if (System.getProperty("wrapper-id") != null) {
@@ -84,18 +119,44 @@ public class CloudNetWrapperConfig {
                 cloudNetHost = System.getProperty("cloudnet-host");
             }
 
+            Optional<String> cloud4Host = Optional.empty();
+            Optional<String> cloud6Host = Optional.empty();
+
             if (cloudNetHost.equals("127.0.0.1") || cloudNetHost.equals("127.0.1.1") || cloudNetHost.split("\\.").length != 4) {
                 String input;
-                System.out.println("Provide the ip address of the cloudnet-master, please");
+                System.out.println("Please provide your master ipv4, leave blank for only ipv6");
+                System.out.println("Only Ipv6 is not recommended!");
                 while ((input = reader.readLine()) != null) {
-                    if ((input.equals("127.0.0.1") || input.equals("127.0.1.1") || input.split("\\.").length != 4)) {
-                        System.out.println("Please provide the real ip address :)");
+                    if (input.isEmpty()) {
+                        cloud4Host = Optional.empty();
+                        break;
+                    }
+                    if (!validator.isValidInet4Address(input)) {
+                        System.out.println("Please provide the real ipv4 address :)");
                         continue;
                     }
-
-                    cloudNetHost = input;
+                    cloud4Host = Optional.of(input);
                     break;
                 }
+
+                System.out.println("please provide your service ipv6, leave blank for only ipv4");
+                while ((input = reader.readLine()) != null) {
+                    if (input.isEmpty()) {
+                        cloud6Host = Optional.empty();
+                        break;
+                    }
+                    if (!validator.isValidInet6Address(input)) {
+                        System.out.println("Please provide the real ipv6 address :)");
+                        continue;
+                    }
+                    cloud6Host = Optional.of(input);
+                    break;
+                }
+            }
+
+            if (!cloud6Host.isPresent() && !cloud4Host.isPresent()) {
+                //TODO: Exit or rerequest data
+                System.exit(0);
             }
 
             long memory = ((NetworkUtils.systemMemory() / 1048576) - 2048);
@@ -104,7 +165,8 @@ public class CloudNetWrapperConfig {
             }
 
             Configuration configuration = new Configuration();
-            configuration.set("connection.cloudnet-host", cloudNetHost);
+            configuration.set("connection.cloudnet-4host", cloud4Host.orElse(""));
+            configuration.set("connection.cloudnet-6host", cloud6Host.orElse(""));
             configuration.set("connection.cloudnet-port", 1410);
             configuration.set("connection.cloudnet-web", 1420);
             configuration.set("general.wrapperId", wrapperId);
@@ -142,7 +204,10 @@ public class CloudNetWrapperConfig {
             this.percentOfCPUForANewProxy = configuration.getDouble("general.percentOfCPUForANewProxy");
             this.percentOfCPUForANewServer = configuration.getDouble("general.percentOfCPUForANewServer");
 
-            this.cloudnetHost = configuration.getString("connection.cloudnet-host");
+            this.cloudnet4Host = !configuration.getString("connection.cloudnet-4host").isEmpty() ? Optional.of(configuration.getString(
+                "connection.cloudnet-4host")) : Optional.empty();
+            this.cloudnet6Host = !configuration.getString("connection.cloudnet-6host").isEmpty() ? Optional.of(configuration.getString(
+                "connection.cloudnet-6host")) : Optional.empty();
             this.cloudnetPort = configuration.getInt("connection.cloudnet-port");
             this.webPort = configuration.getInt("connection.cloudnet-web");
 
@@ -194,12 +259,30 @@ public class CloudNetWrapperConfig {
         return path;
     }
 
-    public String getCloudnetHost() {
-        return cloudnetHost;
+    public Optional<InetAddress> getCloudnetHost() {
+        try {
+            InetAddressValidator validator = new InetAddressValidator();
+            if (cloudnet6Host.isPresent() && validator.isValidInet6Address(cloudnet6Host.get())) {
+                return Optional.of(InetAddress.getByName(cloudnet6Host.get()));
+            }
+
+            if (cloudnet4Host.isPresent() && validator.isValidInet6Address(cloudnet4Host.get())) {
+                return Optional.of(InetAddress.getByName(cloudnet4Host.get()));
+            }
+        } catch (UnknownHostException ignore) {
+        }
+
+        System.err.println("No valid cloudnet Host!");
+        return Optional.empty();
     }
 
-    public String getInternalIP() {
-        return internalIP;
+    public InetAddress getInternalIP() {
+        try {
+            return InetAddress.getByName(internalIP);
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     public String getProxyConfigHost() {

--- a/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/CloudNetWrapperConfig.java
+++ b/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/CloudNetWrapperConfig.java
@@ -61,37 +61,37 @@ public class CloudNetWrapperConfig {
             Optional<String> host6Name = Optional.empty();
             InetAddressValidator validator = new InetAddressValidator();
 
-            if (hostName.equals("127.0.0.1") || hostName.equals("127.0.1.1") || hostName.split("\\.").length != 4) {
-                String input;
-                System.out.println("Please provide your service ipv4, leave blank for only ipv6");
-                System.out.println("Only Ipv6 is not recommended!");
-                while ((input = reader.readLine()) != null) {
-                    if (input.isEmpty()) {
-                        host4Name = Optional.empty();
-                        break;
-                    }
-                    if (!validator.isValidInet4Address(input)) {
-                        System.out.println("Please provide your real ipv4 address :)");
-                        continue;
-                    }
-                    host4Name = Optional.of(input);
+            //if (hostName.equals("127.0.0.1") || hostName.equals("127.0.1.1") || hostName.split("\\.").length != 4) {
+            String input;
+            System.out.println("Please provide your service ipv4, leave blank for only ipv6");
+            System.out.println("Only Ipv6 is not recommended!");
+            while ((input = reader.readLine()) != null) {
+                if (input.isEmpty()) {
+                    host4Name = Optional.empty();
                     break;
                 }
-
-                System.out.println("please provide your service ipv6, leave blank for only ipv4");
-                while ((input = reader.readLine()) != null) {
-                    if (input.isEmpty()) {
-                        host6Name = Optional.empty();
-                        break;
-                    }
-                    if (!validator.isValidInet6Address(input)) {
-                        System.out.println("Please provide your real ipv6 address :)");
-                        continue;
-                    }
-                    host6Name = Optional.of(input);
-                    break;
+                if (!validator.isValidInet4Address(input)) {
+                    System.out.println("Please provide your real ipv4 address :)");
+                    continue;
                 }
+                host4Name = Optional.of(input);
+                break;
             }
+
+            System.out.println("please provide your service ipv6, leave blank for only ipv4");
+            while ((input = reader.readLine()) != null) {
+                if (input.isEmpty()) {
+                    host6Name = Optional.empty();
+                    break;
+                }
+                if (!validator.isValidInet6Address(input)) {
+                    System.out.println("Please provide your real ipv6 address :)");
+                    continue;
+                }
+                host6Name = Optional.of(input);
+                break;
+            }
+            //}
 
             if (!host4Name.isPresent() && !host6Name.isPresent()) {
                 //TODO: Exit or rerequest data
@@ -122,37 +122,36 @@ public class CloudNetWrapperConfig {
             Optional<String> cloud4Host = Optional.empty();
             Optional<String> cloud6Host = Optional.empty();
 
-            if (cloudNetHost.equals("127.0.0.1") || cloudNetHost.equals("127.0.1.1") || cloudNetHost.split("\\.").length != 4) {
-                String input;
-                System.out.println("Please provide your master ipv4, leave blank for only ipv6");
-                System.out.println("Only Ipv6 is not recommended!");
-                while ((input = reader.readLine()) != null) {
-                    if (input.isEmpty()) {
-                        cloud4Host = Optional.empty();
-                        break;
-                    }
-                    if (!validator.isValidInet4Address(input)) {
-                        System.out.println("Please provide the real ipv4 address :)");
-                        continue;
-                    }
-                    cloud4Host = Optional.of(input);
+            //if (cloudNetHost.equals("127.0.0.1") || cloudNetHost.equals("127.0.1.1") || cloudNetHost.split("\\.").length != 4) {
+            System.out.println("Please provide your master ipv4, leave blank for only ipv6");
+            System.out.println("Only Ipv6 is not recommended!");
+            while ((input = reader.readLine()) != null) {
+                if (input.isEmpty()) {
+                    cloud4Host = Optional.empty();
                     break;
                 }
-
-                System.out.println("please provide your service ipv6, leave blank for only ipv4");
-                while ((input = reader.readLine()) != null) {
-                    if (input.isEmpty()) {
-                        cloud6Host = Optional.empty();
-                        break;
-                    }
-                    if (!validator.isValidInet6Address(input)) {
-                        System.out.println("Please provide the real ipv6 address :)");
-                        continue;
-                    }
-                    cloud6Host = Optional.of(input);
-                    break;
+                if (!validator.isValidInet4Address(input)) {
+                    System.out.println("Please provide the real ipv4 address :)");
+                    continue;
                 }
+                cloud4Host = Optional.of(input);
+                break;
             }
+
+            System.out.println("please provide your service ipv6, leave blank for only ipv4");
+            while ((input = reader.readLine()) != null) {
+                if (input.isEmpty()) {
+                    cloud6Host = Optional.empty();
+                    break;
+                }
+                if (!validator.isValidInet6Address(input)) {
+                    System.out.println("Please provide the real ipv6 address :)");
+                    continue;
+                }
+                cloud6Host = Optional.of(input);
+                break;
+            }
+            // }
 
             if (!cloud6Host.isPresent() && !cloud4Host.isPresent()) {
                 //TODO: Exit or rerequest data
@@ -204,9 +203,9 @@ public class CloudNetWrapperConfig {
             this.percentOfCPUForANewProxy = configuration.getDouble("general.percentOfCPUForANewProxy");
             this.percentOfCPUForANewServer = configuration.getDouble("general.percentOfCPUForANewServer");
 
-            this.cloudnet4Host = !configuration.getString("connection.cloudnet-4host").isEmpty() ? Optional.of(configuration.getString(
+            this.cloudnet4Host = !configuration.getString("connection.cloudnet-4host").equals("") ? Optional.of(configuration.getString(
                 "connection.cloudnet-4host")) : Optional.empty();
-            this.cloudnet6Host = !configuration.getString("connection.cloudnet-6host").isEmpty() ? Optional.of(configuration.getString(
+            this.cloudnet6Host = !configuration.getString("connection.cloudnet-4host").equals("") ? Optional.of(configuration.getString(
                 "connection.cloudnet-6host")) : Optional.empty();
             this.cloudnetPort = configuration.getInt("connection.cloudnet-port");
             this.webPort = configuration.getInt("connection.cloudnet-web");
@@ -261,12 +260,13 @@ public class CloudNetWrapperConfig {
 
     public Optional<InetAddress> getCloudnetHost() {
         try {
+
             InetAddressValidator validator = new InetAddressValidator();
             if (cloudnet6Host.isPresent() && validator.isValidInet6Address(cloudnet6Host.get())) {
                 return Optional.of(InetAddress.getByName(cloudnet6Host.get()));
             }
 
-            if (cloudnet4Host.isPresent() && validator.isValidInet6Address(cloudnet4Host.get())) {
+            if (cloudnet4Host.isPresent() && validator.isValidInet4Address(cloudnet4Host.get())) {
                 return Optional.of(InetAddress.getByName(cloudnet4Host.get()));
             }
         } catch (UnknownHostException ignore) {

--- a/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/bootstrap/CloudBootstrap.java
+++ b/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/bootstrap/CloudBootstrap.java
@@ -22,7 +22,8 @@ public class CloudBootstrap {
     public static void main(String[] args) throws Exception {
 
         System.setProperty("file.encoding", "UTF-8");
-        System.setProperty("java.net.preferIPv4Stack", "true");
+        System.setProperty("java.net.preferIPv6Stack", "true");
+        System.setProperty("java.net.preferIPv4Stack", "false");
 
         OptionParser optionParser = new OptionParser();
 

--- a/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/bootstrap/CloudBootstrap.java
+++ b/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/bootstrap/CloudBootstrap.java
@@ -22,8 +22,6 @@ public class CloudBootstrap {
     public static void main(String[] args) throws Exception {
 
         System.setProperty("file.encoding", "UTF-8");
-        System.setProperty("java.net.preferIPv6Stack", "true");
-        System.setProperty("java.net.preferIPv4Stack", "false");
 
         OptionParser optionParser = new OptionParser();
 

--- a/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/server/BungeeCord.java
+++ b/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/server/BungeeCord.java
@@ -284,10 +284,16 @@ public class BungeeCord extends AbstractScreenService implements ServerDispatche
                       .append("proxyInfo", proxyInfo)
                       .append("memory", proxyProcessMeta.getMemory())
                       .saveAsConfig(cloudPath.resolve("config.json"));
-        new Document().append("connection",
-                              new ConnectableAddress(CloudNetWrapper.getInstance().getWrapperConfig().getCloudnetHost(),
-                                                     CloudNetWrapper.getInstance().getWrapperConfig().getCloudnetPort()))
-                      .saveAsConfig(cloudPath.resolve("connection.json"));
+
+        if (CloudNetWrapper.getInstance().getWrapperConfig().getCloudnetHost().isPresent()) {
+            new Document().append("connection",
+                                  new ConnectableAddress(CloudNetWrapper.getInstance().getWrapperConfig().getCloudnetHost().get(),
+                                                         CloudNetWrapper.getInstance().getWrapperConfig().getCloudnetPort()))
+                          .saveAsConfig(cloudPath.resolve("connection.json"));
+        } else {
+            throw new NullPointerException("No CloudNet host defined!");
+        }
+
 
         StringBuilder commandBuilder = new StringBuilder();
         commandBuilder.append("java ");

--- a/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/server/BungeeCord.java
+++ b/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/server/BungeeCord.java
@@ -23,8 +23,7 @@ import eu.cloudnetservice.cloudnet.v2.wrapper.server.process.ServerDispatcher;
 import eu.cloudnetservice.cloudnet.v2.wrapper.util.FileUtility;
 
 import java.io.IOException;
-import java.net.URL;
-import java.net.URLConnection;
+import java.net.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -142,7 +141,7 @@ public class BungeeCord extends AbstractScreenService implements ServerDispatche
                             Files.createDirectories(groupTemplates);
                             MasterTemplateLoader templateLoader = new MasterTemplateLoader(
                                 String.format("http://%s:%d/cloudnet/api/v1/download",
-                                              CloudNetWrapper.getInstance().getWrapperConfig().getCloudnetHost(),
+                                              CloudNetWrapper.getInstance().getWrapperConfig().getCloudNetHost(),
                                               CloudNetWrapper.getInstance().getWrapperConfig().getWebPort()),
                                 groupTemplates.resolve("template.zip"),
                                 CloudNetWrapper.getInstance().getSimpledUser(),
@@ -208,7 +207,7 @@ public class BungeeCord extends AbstractScreenService implements ServerDispatche
                         Files.createDirectories(groupTemplates);
                         MasterTemplateLoader templateLoader = new MasterTemplateLoader(
                             String.format("http://%s:%d/cloudnet/api/v1/download",
-                                          CloudNetWrapper.getInstance().getWrapperConfig().getCloudnetHost(),
+                                          CloudNetWrapper.getInstance().getWrapperConfig().getCloudNetHost(),
                                           CloudNetWrapper.getInstance().getWrapperConfig().getWebPort()),
                             groupTemplates.resolve("template.zip"),
                             CloudNetWrapper.getInstance().getSimpledUser(),
@@ -260,9 +259,16 @@ public class BungeeCord extends AbstractScreenService implements ServerDispatche
         Files.deleteIfExists(pluginsPath.resolve("CloudNetAPI.jar"));
         FileUtility.insertData("files/CloudNetAPI.jar", pluginsPath.resolve("CloudNetAPI.jar"));
 
-        FileUtility.rewriteFileUtils(this.dir.resolve("config.yml"),
-                                     CloudNetWrapper.getInstance().getWrapperConfig().getProxyConfigHost() +
-                                         ':' + this.proxyProcessMeta.getPort());
+        InetAddress proxyConfigHost = CloudNetWrapper.getInstance().getWrapperConfig().getProxyConfigHost();
+
+        if (proxyConfigHost instanceof Inet4Address) {
+            FileUtility.rewriteFileUtils(this.dir.resolve("config.yml"),
+                                         String.format("%s:%s", proxyConfigHost.getHostAddress(), this.proxyProcessMeta.getPort()));
+        } else if (proxyConfigHost instanceof Inet6Address) {
+            FileUtility.rewriteFileUtils(this.dir.resolve("config.yml"),
+                                         String.format("[%s]:%s", proxyConfigHost.getHostAddress(), this.proxyProcessMeta.getPort()));
+        }
+
 
         this.proxyInfo = new ProxyInfo(proxyProcessMeta.getServiceId(),
                                        CloudNetWrapper.getInstance().getWrapperConfig().getInternalIP(),
@@ -285,14 +291,10 @@ public class BungeeCord extends AbstractScreenService implements ServerDispatche
                       .append("memory", proxyProcessMeta.getMemory())
                       .saveAsConfig(cloudPath.resolve("config.json"));
 
-        if (CloudNetWrapper.getInstance().getWrapperConfig().getCloudnetHost().isPresent()) {
-            new Document().append("connection",
-                                  new ConnectableAddress(CloudNetWrapper.getInstance().getWrapperConfig().getCloudnetHost().get(),
-                                                         CloudNetWrapper.getInstance().getWrapperConfig().getCloudnetPort()))
-                          .saveAsConfig(cloudPath.resolve("connection.json"));
-        } else {
-            throw new NullPointerException("No CloudNet host defined!");
-        }
+        new Document().append("connection",
+                              new ConnectableAddress(CloudNetWrapper.getInstance().getWrapperConfig().getCloudNetHost(),
+                                                     CloudNetWrapper.getInstance().getWrapperConfig().getCloudNetPort()))
+                      .saveAsConfig(cloudPath.resolve("connection.json"));
 
 
         StringBuilder commandBuilder = new StringBuilder();

--- a/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/server/GameServer.java
+++ b/cloudnet-wrapper/src/main/java/eu/cloudnetservice/cloudnet/v2/wrapper/server/GameServer.java
@@ -225,7 +225,7 @@ public class GameServer extends AbstractScreenService implements ServerDispatche
                 try {
                     URLConnection urlConnection = new URL(
                         String.format("http://%s:%d/cloudnet/api/v1/download",
-                                      CloudNetWrapper.getInstance().getWrapperConfig().getCloudnetHost(),
+                                      CloudNetWrapper.getInstance().getWrapperConfig().getCloudNetHost(),
                                       CloudNetWrapper.getInstance().getWrapperConfig().getWebPort())).openConnection();
                     urlConnection.setRequestProperty("User-Agent", NetworkUtils.USER_AGENT);
 
@@ -407,7 +407,7 @@ public class GameServer extends AbstractScreenService implements ServerDispatche
             properties.setProperty(x, this.serverProcessMeta.getProperties().getProperty(x));
         }
 
-        properties.setProperty("server-ip", CloudNetWrapper.getInstance().getWrapperConfig().getInternalIP().toString());
+        properties.setProperty("server-ip", CloudNetWrapper.getInstance().getWrapperConfig().getInternalIP().getHostAddress());
         properties.setProperty("server-port", serverProcessMeta.getPort() + NetworkUtils.EMPTY_STRING);
 
         String motd = properties.getProperty("motd");
@@ -496,16 +496,10 @@ public class GameServer extends AbstractScreenService implements ServerDispatche
                       .append("memory", serverProcessMeta.getMemory())
                       .saveAsConfig(cloudPath.resolve("config.json"));
 
-        if (CloudNetWrapper.getInstance().getWrapperConfig().getCloudnetHost().isPresent()) {
-            new Document("connection",
-                         new ConnectableAddress(CloudNetWrapper.getInstance().getWrapperConfig().getCloudnetHost().get(),
-                                                CloudNetWrapper.getInstance().getWrapperConfig().getCloudnetPort()))
-                .saveAsConfig(cloudPath.resolve("connection.json"));
-        } else {
-            throw new NullPointerException("No CloudNet host defined!");
-        }
-
-
+        new Document("connection",
+                     new ConnectableAddress(CloudNetWrapper.getInstance().getWrapperConfig().getCloudNetHost(),
+                                            CloudNetWrapper.getInstance().getWrapperConfig().getCloudNetPort()))
+            .saveAsConfig(cloudPath.resolve("connection.json"));
     }
 
     /**
@@ -518,16 +512,10 @@ public class GameServer extends AbstractScreenService implements ServerDispatche
         commandBuilder.append("java ");
         for (String command : serverProcessMeta.getJavaProcessParameters()) {
             commandBuilder.append(command).append(NetworkUtils.SPACE_STRING);
-
-            commandBuilder.append("-Dfile.encoding=UTF-8 -Dcom.mojang.eula.agree=true -Djline.terminal=jline.UnsupportedTerminal -Xmx")
-                          .append(serverProcessMeta.getMemory())
-                          .append("M -jar ");
-
         }
-
-        for (String command : serverProcessMeta.getServerProcessParameters()) {
-            commandBuilder.append(command).append(NetworkUtils.SPACE_STRING);
-        }
+        commandBuilder.append("-Dfile.encoding=UTF-8 -Dcom.mojang.eula.agree=true -Djline.terminal=jline.UnsupportedTerminal -Xmx")
+                      .append(serverProcessMeta.getMemory())
+                      .append("M -jar ");
 
         switch (serverGroup.getServerType()) {
             case CAULDRON:
@@ -542,6 +530,10 @@ public class GameServer extends AbstractScreenService implements ServerDispatche
             default:
                 commandBuilder.append("spigot.jar nogui");
                 break;
+        }
+
+        for (String command : serverProcessMeta.getServerProcessParameters()) {
+            commandBuilder.append(command).append(NetworkUtils.SPACE_STRING);
         }
 
         this.instance = Runtime.getRuntime().exec(commandBuilder.toString().split(NetworkUtils.SPACE_STRING), null, this.dir.toFile());
@@ -581,7 +573,7 @@ public class GameServer extends AbstractScreenService implements ServerDispatche
             Files.createDirectories(groupTemplates);
             MasterTemplateLoader templateLoader = new MasterTemplateLoader(
                 String.format("http://%s:%d/cloudnet/api/v1/download",
-                              CloudNetWrapper.getInstance().getWrapperConfig().getCloudnetHost(),
+                              CloudNetWrapper.getInstance().getWrapperConfig().getCloudNetHost(),
                               CloudNetWrapper.getInstance().getWrapperConfig().getWebPort()),
                 groupTemplates.resolve("template.zip"),
                 CloudNetWrapper.getInstance().getSimpledUser(),
@@ -702,27 +694,18 @@ public class GameServer extends AbstractScreenService implements ServerDispatche
         }
 
         if (template != null && template.getBackend().equals(TemplateResource.MASTER)) {
+            MasterTemplateDeploy masterTemplateDeploy =
+                new MasterTemplateDeploy(this.dir,
+                                         new ConnectableAddress(CloudNetWrapper.getInstance().getWrapperConfig().getCloudNetHost(),
+                                                                CloudNetWrapper.getInstance().getWrapperConfig().getWebPort()),
+                                         CloudNetWrapper.getInstance().getSimpledUser(),
+                                         template,
+                                         serverGroup.getName());
 
-            if (CloudNetWrapper.getInstance().getWrapperConfig().getCloudnetHost().isPresent()) {
-                MasterTemplateDeploy masterTemplateDeploy =
-                    new MasterTemplateDeploy(this.dir,
-                                             new ConnectableAddress(CloudNetWrapper.getInstance()
-                                                                                   .getWrapperConfig()
-                                                                                   .getCloudnetHost()
-                                                                                   .get(),
-                                                                    CloudNetWrapper.getInstance().getWrapperConfig().getWebPort()),
-                                             CloudNetWrapper.getInstance().getSimpledUser(),
-                                             template,
-                                             serverGroup.getName());
-
-                try {
-                    masterTemplateDeploy.deploy();
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-
-            } else {
-                throw new NullPointerException("No CloudNet host defined!");
+            try {
+                masterTemplateDeploy.deploy();
+            } catch (Exception e) {
+                e.printStackTrace();
             }
 
         } else if (template != null) {

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <dependency.semver4j.version>3.1.0</dependency.semver4j.version>
         <dependency.guava.version>29.0-jre</dependency.guava.version>
         <dependency.slf4j.version>1.7.30</dependency.slf4j.version>
+        <dependency.commons-validator.version>1.7</dependency.commons-validator.version>
         <!-- test dependencies -->
         <test.junit.version>4.13</test.junit.version>
         <!-- Plugins -->


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU HAVE READ CLOUDNET'S CODESTYLE GUIDELINES -->
<!-- IF YOU'RE NOT FOLLOWING CLOUDNET'S CODESTYLE GUIDELINES, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->
<!-- IF YOU'RE NOT PROVIDING ANY INFORMATION, THEN THIS PULL REQUEST IS LIKELY TO BE REJECTED -->

This pull request includes:

- [x] breaking changes (changed types and a changed method name)
- [ ] no breaking changes

### Changes made to the repository:

<!-- A brief description of the changes done in this pull request. -->
This pull request changes part of the setup of the wrapper, allowing users to configure IPv6 and Dual Stack addresses (`0.0.0.0`).
On top of that, the API was changed to properly support Internet Addresses instead of strings.

### Documentation of test results:

<!-- Add test results before and after applying your changes. -->
Test results:
- Configuration (only relevant parts):
  - Master: 
    - `config.yml`: 
![image](https://user-images.githubusercontent.com/2050966/94460746-7f39bd00-01b9-11eb-8a1a-e23478ccc403.png)
    - `services.json`:
![image](https://user-images.githubusercontent.com/2050966/94460862-a42e3000-01b9-11eb-8c3e-3188fe448fb7.png)
  - Wrapper:
    - `config.yml`:
![image](https://user-images.githubusercontent.com/2050966/94461012-d8095580-01b9-11eb-8185-1dc857f22231.png)


Connections to the proxy in this configuration are able to be done over an internal IPv6 link.  
Using `0.0.0.0` as the `proxy-config-host` yields dual-stack capabilities, allowing IPv4 and IPv6 connections.



### Related issues/discussions:

This is a follow-up to #281.
Closes #275.
<!-- Add any related issues here by mentioning them (e.g. Fixes #1). -->  
