### PR TITLE
Removing the manuell download links and replacing them with an automatic system

### DIFF
--- a/cloudnet-app-lib/cloudnet-setup/src/main/java/eu/cloudnetservice/cloudnet/v2/setup/models/GetBukkitVersion.java
+++ b/cloudnet-app-lib/cloudnet-setup/src/main/java/eu/cloudnetservice/cloudnet/v2/setup/models/GetBukkitVersion.java
@@ -1,0 +1,56 @@
+package eu.cloudnetservice.cloudnet.v2.setup.models;
+
+import eu.cloudnetservice.cloudnet.v2.lib.NetworkUtils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+
+public class GetBukkitVersion {
+    private final String version;
+    private final URL previewURL;
+
+    public GetBukkitVersion(String version, URL previewDownload) {
+        this.version = version;
+        this.previewURL = previewDownload;
+    }
+
+    private URL revealDownload() {
+        try {
+            URLConnection connection = previewURL.openConnection();
+            connection.setRequestProperty("User-Agent", NetworkUtils.USER_AGENT);
+            connection.connect();
+
+            InputStream input = connection.getInputStream();
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(input))) {
+                for (;;) {
+                    String line = reader.readLine();
+                    if (line == null) break;
+                    if (!line.contains("href=\"https://cdn.getbukkit.org/spigot")) continue;
+
+                    int linkStart = line.indexOf("\"");
+                    linkStart++;
+                    int linkEnds = line.indexOf("\"", linkStart);
+
+                    String downloadLink = line.substring(linkStart, linkEnds);
+                    return new URL(downloadLink);
+                }
+            }
+        } catch (IOException exception) {
+            exception.printStackTrace();
+        }
+        return null;
+    }
+
+    public URL getDownloadURL() {
+        return revealDownload(); //Only load when needed to minimize delay
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+}

--- a/cloudnet-app-lib/cloudnet-setup/src/main/java/eu/cloudnetservice/cloudnet/v2/setup/models/GetBukkitVersion.java
+++ b/cloudnet-app-lib/cloudnet-setup/src/main/java/eu/cloudnetservice/cloudnet/v2/setup/models/GetBukkitVersion.java
@@ -26,9 +26,8 @@ public class GetBukkitVersion {
 
             InputStream input = connection.getInputStream();
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(input))) {
-                while (true) {
-                    String line = reader.readLine();
-                    if (line == null) break;
+                String line;
+                while ((line = reader.readLine()) != null) {
                     if (!line.contains("href=\"https://cdn.getbukkit.org/spigot")) continue;
 
                     int linkStart = line.indexOf("\"");

--- a/cloudnet-app-lib/cloudnet-setup/src/main/java/eu/cloudnetservice/cloudnet/v2/setup/models/GetBukkitVersion.java
+++ b/cloudnet-app-lib/cloudnet-setup/src/main/java/eu/cloudnetservice/cloudnet/v2/setup/models/GetBukkitVersion.java
@@ -26,7 +26,7 @@ public class GetBukkitVersion {
 
             InputStream input = connection.getInputStream();
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(input))) {
-                for (;;) {
+                while (true) {
                     String line = reader.readLine();
                     if (line == null) break;
                     if (!line.contains("href=\"https://cdn.getbukkit.org/spigot")) continue;

--- a/cloudnet-app-lib/cloudnet-setup/src/main/java/eu/cloudnetservice/cloudnet/v2/setup/spigot/GetBukkitVersions.java
+++ b/cloudnet-app-lib/cloudnet-setup/src/main/java/eu/cloudnetservice/cloudnet/v2/setup/spigot/GetBukkitVersions.java
@@ -1,0 +1,85 @@
+package eu.cloudnetservice.cloudnet.v2.setup.spigot;
+
+import eu.cloudnetservice.cloudnet.v2.lib.NetworkUtils;
+import eu.cloudnetservice.cloudnet.v2.setup.models.GetBukkitVersion;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.ArrayList;
+
+public class GetBukkitVersions {
+    private static final String versionsUrl = "https://getbukkit.org/download/spigot";
+
+    /**
+     * Loads a list of all Spigot Versions available on getbukkit.org
+     *
+     * @param minVersion All versions bellow this version will be ignored
+     * @return array of versions
+     */
+    public static GetBukkitVersion[] getVersions(@Nullable String minVersion) {
+        ArrayList<GetBukkitVersion> versions = new ArrayList<>();
+        try {
+            URL url = new URL(versionsUrl);
+            URLConnection connection = url.openConnection();
+            connection.setRequestProperty("User-Agent", NetworkUtils.USER_AGENT);
+            connection.connect();
+
+            InputStream input = connection.getInputStream();
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(input))) {
+                String currentVersion = null;
+
+                boolean exitAfter = false; //Is true when minimum version is reached
+                short searchFor = 0; //0 -> "Version" Text; 1 -> Actual Version; 2 -> Download Link
+
+                while (true) {
+                    String line = reader.readLine();
+                    if (line == null) break;
+
+                    if (line.contains("Version")) {
+                        searchFor = 1;
+                        continue;
+                    }
+
+                    if (searchFor == 1) {
+                        int versionStart = line.indexOf(">");
+                        versionStart++;
+                        int versionEnd = line.indexOf("<", versionStart);
+                        String version = line.substring(versionStart, versionEnd);
+
+                        currentVersion = version;
+                        searchFor = 2;
+
+                        if (version.equals(minVersion))
+                            exitAfter = true;
+                        continue;
+                    }
+
+                    if (searchFor == 2) {
+                        if (!line.contains("href=\"https://getbukkit.org/get/")) continue;
+
+                        int linkStart = line.indexOf("\"");
+                        linkStart++;
+                        int linkEnds = line.indexOf("\"", linkStart);
+
+                        String downloadPreview = line.substring(linkStart, linkEnds);
+                        URL previewURL = new URL(downloadPreview);
+                        GetBukkitVersion version = new GetBukkitVersion(currentVersion, previewURL);
+
+                        versions.add(version);
+                        searchFor = 0;
+                        if (exitAfter) break;
+                    }
+                }
+            }
+        } catch (IOException exception) {
+            exception.printStackTrace();
+        }
+        return versions.toArray(new GetBukkitVersion[0]);
+    }
+
+}

--- a/cloudnet-app-lib/cloudnet-setup/src/main/java/eu/cloudnetservice/cloudnet/v2/setup/spigot/GetBukkitVersions.java
+++ b/cloudnet-app-lib/cloudnet-setup/src/main/java/eu/cloudnetservice/cloudnet/v2/setup/spigot/GetBukkitVersions.java
@@ -36,10 +36,8 @@ public class GetBukkitVersions {
                 boolean exitAfter = false; //Is true when minimum version is reached
                 short searchFor = 0; //0 -> "Version" Text; 1 -> Actual Version; 2 -> Download Link
 
-                while (true) {
-                    String line = reader.readLine();
-                    if (line == null) break;
-
+                String line;
+                while ((line = reader.readLine()) != null) {
                     if (line.contains("Version")) {
                         searchFor = 1;
                         continue;

--- a/cloudnet-app-lib/cloudnet-setup/src/main/java/eu/cloudnetservice/cloudnet/v2/setup/spigot/SetupSpigotVersion.java
+++ b/cloudnet-app-lib/cloudnet-setup/src/main/java/eu/cloudnetservice/cloudnet/v2/setup/spigot/SetupSpigotVersion.java
@@ -18,6 +18,7 @@
 package eu.cloudnetservice.cloudnet.v2.setup.spigot;
 
 import eu.cloudnetservice.cloudnet.v2.lib.NetworkUtils;
+import eu.cloudnetservice.cloudnet.v2.setup.models.GetBukkitVersion;
 import jline.console.ConsoleReader;
 
 import java.io.IOException;
@@ -28,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -81,57 +83,36 @@ public class SetupSpigotVersion implements Consumer<ConsoleReader> {
     }
 
     private boolean installSpigot(ConsoleReader reader) {
-        System.out.println(
-            "Choose a Spigot version [\"1.8.8\", \"1.9.4\", \"1.10.2\", \"1.11.2\", \"1.12.2\", \"1.13\", \"1.13.1\", \"1.13.2\", \"1.14\", \"1.14.1\", \"1.14.2\", \"1.14.3\", \"1.14.4\", \"1.15\", \"1.15.1\", \"1.15.2\", \"1.16.1\", \"1.16.2\", \"1.16.3\", \"1.16.4\"]");
+        GetBukkitVersion[] versions = GetBukkitVersions.getVersions("1.8.8");
+
+        StringBuilder builder = new StringBuilder("Choose a Spigot version [");
+        builder.append(versions[0].getVersion());
+        for (int i = 1; i < versions.length; i++) {
+            GetBukkitVersion version = versions[i];
+            builder.append(", \"")
+                   .append(version.getVersion())
+                   .append("\"");
+        }
+        builder.append("]");
+        System.out.println(builder.toString());
+
+        HashMap<String, GetBukkitVersion> versionsMap = new HashMap<>();
+        for (GetBukkitVersion version : versions)
+            versionsMap.put(version.getVersion(), version);
+
         while (true) {
             try {
-                switch (reader.readLine().toLowerCase()) {
-                    case "1.8.8":
-                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.8.8-R0.1-SNAPSHOT-latest.jar");
-                    case "1.9.4":
-                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.9.4-R0.1-SNAPSHOT-latest.jar");
-                    case "1.10.2":
-                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.10.2-R0.1-SNAPSHOT-latest.jar");
-                    case "1.11.2":
-                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.11.2.jar");
-                    case "1.12.2":
-                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.12.2.jar");
-                    case "1.13":
-                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.13.jar");
-                    case "1.13.1":
-                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.13.1.jar");
-                    case "1.13.2":
-                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.13.2.jar");
-                    case "1.14":
-                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.14.jar");
-                    case "1.14.1":
-                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.14.1.jar");
-                    case "1.14.2":
-                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.14.2.jar");
-                    case "1.14.3":
-                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.14.3.jar");
-                    case "1.14.4":
-                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.14.4.jar");
-                    case "1.15":
-                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.15.jar");
-                    case "1.15.1":
-                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.15.1.jar");
-                    case "1.15.2":
-                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.15.2.jar");
-                    case "1.16.1":
-                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.16.1.jar");
-                    case "1.16.2":
-                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.16.2.jar");
-                    case "1.16.3":
-                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.16.3.jar");
-                    case "1.16.4":
-                        return this.download.test("https://cdn.getbukkit.org/spigot/spigot-1.16.4.jar");
-                    default:
-                        System.out.println("This version is not supported!");
-                        break;
+                String input = reader.readLine().toLowerCase();
+                if (!versionsMap.containsKey(input)) {
+                    System.out.println("This version is not supported!");
+                    continue;
                 }
-            } catch (IOException e) {
-                e.printStackTrace();
+
+                GetBukkitVersion version = versionsMap.get(input);
+                URL url = version.getDownloadURL();
+                return download.test(url.toString());
+            } catch (IOException exception) {
+                exception.printStackTrace();
             }
         }
     }


### PR DESCRIPTION
This pull request includes:

- [ ] breaking changes
- [X] no breaking changes

### Changes made to the repository:
I removed the manuell download links for GetBukkit.org and replaced them with a system that automaticaly gets all versions that can be downloaded from GetBukkit.org.

### Documentation of test results:
Just tested if the funktion works as intended and if performance is okay (it worked and I improved performance after testing)

### Related issues/discussions:
No related issues
